### PR TITLE
Add PVStructure::getAs<>()

### DIFF
--- a/src/pv/pvData.h
+++ b/src/pv/pvData.h
@@ -703,6 +703,34 @@ public:
             return std::tr1::shared_ptr<PVT>();
     }
 
+private:
+    PVField *GetAsImpl(const char *name) const;
+public:
+
+    /**
+     * Get a subfield with the specified name.
+     * @param name a '.' seperated list of child field names (no whitespace allowed)
+     * @returns A reference to the sub-field (never NULL)
+     * @throws std::runtime_error if the requested sub-field doesn't exist, or has a different type
+     * @code
+     *   PVInt& ref = pvStruct->getAs<PVInt>("substruct.leaffield");
+     * @endcode
+     */
+    template<typename PVT>
+    PVT& getAs(const char *name) const
+    {
+        PVT *raw = dynamic_cast<PVT*>(GetAsImpl(name));
+        if(!raw)
+            throw std::runtime_error("Field has wrong type");
+        return *raw;
+    }
+
+    template<typename PVT>
+    FORCE_INLINE PVT& getAs(std::string const &fieldName) const
+    {
+        return this->getAs<PVT>(fieldName.c_str());
+    }
+
     /**
      * Get a boolean field with the specified name.
      * @deprecated No longer needed. Use templete version of getSubField


### PR DESCRIPTION
Access to sub-fields of a structure with exceptions thrown if this is not possible. Addresses #2.

Replaces findSubField() with private method PVStructure::GetAsImpl(), which uses char* instead of std::string to avoid temporary allocations.  Loops instead of recursing.  Also, uses exception messages to give some hint about why the lookup fails.