### PR TITLE
GetSubFieldT

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ The main changes since release 4.0 are:
 * Convert::copyUnion now always copies between subfields.
 * CreateRequest prevents a possible SEGFAULT.
 * New stream operators for Field and PVField are provided.
-* New method getAs that is like getSubField except that it throws exception
+* New method getSubFieldT that is like getSubField except that it throws exception
 
 Convert copy methods and equals operators
 -----------------------------------------
@@ -73,10 +73,10 @@ Now it can be done as follows:
          cout << pv << endl;
      }
 
-New method getAs that is like getSubField except that it throws exception
+New method getSubFieldT that is like getSubField except that it throws exception
 --------------------
 
-<b>PVStructure</b> has a new template member <b>getAs(const char *name)</b>
+<b>PVStructure</b> has a new template member <b>getSubFieldT(std::string const &fieldName)</b>
 that is like <b>getSubField</b> except that it throws a runtime_error
 instead of returning null.
 

--- a/documentation/pvDataCPP.html
+++ b/documentation/pvDataCPP.html
@@ -2309,15 +2309,15 @@ public:
     template&lt;typename PVT&gt;
     std::tr1::shared_ptr&lt;PVT&gt; getSubField(std::size_t fieldOffset) const
 
-    PVField&amp; getSubFieldT(std::string const &amp;fieldName) const;
+    PVFieldPtr getSubFieldT(std::string const &amp;fieldName) const;
 
     template&lt;typename PVT&gt;
-    PVT&amp; getSubFieldT(std::string const &amp;fieldName) const
+    std::tr1::shared_ptr&lt;PVT&gt; getSubFieldT(std::string const &amp;fieldName) const
 
-    PVField&amp; getSubFieldT(std::size_t fieldOffset) const;
+    PVFieldPtr getSubFieldT(std::size_t fieldOffset) const;
 
     template&lt;typename PVT&gt;
-    PVT&amp; getSubFieldT(std::size_t fieldOffset) const
+    std::tr1::shared_ptr&lt;PVT&gt; getSubFieldT(std::size_t fieldOffset) const
 
     virtual void serialize(
         ByteBuffer *pbuffer,SerializableControl *pflusher) const ;

--- a/documentation/pvDataCPP.html
+++ b/documentation/pvDataCPP.html
@@ -465,10 +465,10 @@ structure
     PVStructurePtr doubleValue = getPVDataCreate()-&gt;createPVStructure(
         getStandardField()-&gt;scalar(pvDouble,"alarm,timeStamp"));
     PVDoublePtr pvdouble =
-        doubleValue-&gt;getAs&lt;PVDouble&gt;("value");
+        doubleValue-&gt;getSubField&lt;PVDouble&gt;("value");
     pvdouble-&gt;put(1e5);
     cout &lt;&lt; *doubleValue &lt;&lt; endl;
-    double value = doubleValue-&gt;getAs&lt;PVDouble&gt;("value")-&gt;get();
+    double value = doubleValue-&gt;getSubField&lt;PVDouble&gt;("value")-&gt;get();
     cout &lt;&lt; "from get " &lt;&lt; value &lt;&lt; "\n\n";
 </pre>
 This produces:
@@ -491,7 +491,7 @@ from get 100000
     PVStructurePtr doubleArrayValue = pvDataCreate-&gt;createPVStructure(
         standardField-&gt;scalarArray(pvDouble,"alarm,timeStamp"));
     PVDoubleArrayPtr pvDoubleArray =
-         doubleArrayValue-&gt;getAs&lt;PVDoubleArray&gt;("value");
+         doubleArrayValue-&gt;getSubField&lt;PVDoubleArray&gt;("value");
     size_t len = 10;
     shared_vector&lt;double&gt; xxx(len);
     for(size_t i=0; i&lt; len; ++i) xxx[i] = i;
@@ -605,10 +605,10 @@ structure
                 createUnion(),
             "alarm,timeStamp"));
     PVStructurePtr pvTimeStamp =
-        pvStructure-&gt;getAs&lt;PVUnion&gt;("value")-&gt;select&lt;PVStructure&gt;(2);
-    pvTimeStamp-&gt;getAs&lt;PVLong&gt;("secondsPastEpoch")-&gt;put(1000);
+        pvStructure-&gt;getSubField&lt;PVUnion&gt;("value")-&gt;select&lt;PVStructure&gt;(2);
+    pvTimeStamp-&gt;getSubField&lt;PVLong&gt;("secondsPastEpoch")-&gt;put(1000);
     cout &lt;&lt; *pvStructure) &lt;&lt; "\n";
-    pvStructure-&gt;getAs&lt;PVUnion&gt;("value")-&gt;select&lt;PVDouble&gt;(0)-&gt;put(1e5);
+    pvStructure-&gt;getSubField&lt;PVUnion&gt;("value")-&gt;select&lt;PVDouble&gt;(0)-&gt;put(1e5);
     cout &lt;&lt; *pvStructure &lt;&lt; "\n\n";
 </pre>
 This produces:
@@ -648,13 +648,13 @@ epics:nt/NTUnion:1.0
         standardField-&gt;variantUnion("alarm,timeStamp"));
     PVStructurePtr pvTimeStamp =
         pvDataCreate-&gt;createPVStructure(standardField-&gt;timeStamp());
-    pvStructure-&gt;getAs&lt;PVUnion&gt;("value")-&gt;set(pvTimeStamp);
-    pvTimeStamp-&gt;getAs&lt;PVLong&gt;("secondsPastEpoch")-&gt;put(1000);
+    pvStructure-&gt;getSubField&lt;PVUnion&gt;("value")-&gt;set(pvTimeStamp);
+    pvTimeStamp-&gt;getSubField&lt;PVLong&gt;("secondsPastEpoch")-&gt;put(1000);
     cout &lt;&lt; *pvStructure &lt;&lt; "\n";
-    pvStructure-&gt;getAs&lt;PVUnion&gt;("value")-&gt;set(
+    pvStructure-&gt;getSubField&lt;PVUnion&gt;("value")-&gt;set(
         pvDataCreate-&gt;createPVScalar(pvDouble));
     PVDoublePtr pvValue = static_pointer_cast&lt;PVDouble&gt;(
-        pvStructure-&gt;getAs&lt;PVUnion&gt;("value")-&gt;get());
+        pvStructure-&gt;getSubField&lt;PVUnion&gt;("value")-&gt;get());
     pvValue-&gt;put(1e5);
     cout &lt;&lt; *pvStructure &lt;&lt; "\n\n";
 </pre>
@@ -718,7 +718,7 @@ epics:nt/NTUnion:1.0
     cout &lt;&lt; *pvStructure-&gt;getStructure() &lt;&lt; endl;
     cout &lt;&lt; "data\n";
     cout &lt;&lt; *pvStructure &lt;&lt; "\n";
-    PVUnionPtr pvUnion = pvStructure-&gt;getAs&lt;PVUnion&gt;("value");;
+    PVUnionPtr pvUnion = pvStructure-&gt;getSubField&lt;PVUnion&gt;("value");;
     pvUnion-&gt;select("doubleValue");
     PVDoublePtr pvDouble = pvUnion-&gt;get&lt;PVDouble&gt;();
     pvDouble-&gt;put(1.55);
@@ -726,7 +726,7 @@ epics:nt/NTUnion:1.0
     cout &lt;&lt; *pvStructure &lt;&lt; "\n";
     cout &lt;&lt; "value = " &lt;&lt; pvDouble-&gt;get() &lt;&lt; "\n";
     pvUnion-&gt;select("structValue");
-    pvDouble = pvUnion-&gt;get&lt;PVStructure&gt;()-&gt;getAs&lt;PVDouble&gt;("doubleValue");
+    pvDouble = pvUnion-&gt;get&lt;PVStructure&gt;()-&gt;getSubField&lt;PVDouble&gt;("doubleValue");
     pvDouble-&gt;put(1.65);
     cout &lt;&lt; "select structValue\n";
     cout &lt;&lt; *pvStructure &lt;&lt; "\n";
@@ -2304,13 +2304,13 @@ public:
     template&lt;typename PVT&gt;
     std::tr1::shared_ptr&lt;PVT&gt; getSubField(std::string const &amp;fieldName) const
 
-    template&lt;typename PVT&gt;
-    PVT&amp; getAs(const char *name) const;
-
     PVFieldPtr getSubField(std::size_t fieldOffset) const;
 
     template&lt;typename PVT&gt;
     std::tr1::shared_ptr&lt;PVT&gt; getSubField(std::size_t fieldOffset) const
+
+    template&lt;typename PVT&gt;
+    PVT&amp; getSubFieldT(std::string const &amp;fieldName) const;
 
     virtual void serialize(
         ByteBuffer *pbuffer,SerializableControl *pflusher) const ;
@@ -2332,9 +2332,6 @@ public:
   <dt>getPVFields</dt>
     <dd>Returns the array of subfields. The set of subfields must all have
       different field names.</dd>
-  <dt>getAs(const char *name)</dt>
-     <dd>Like the getSubField except that it throws std::runtime_error if
-       the field does not exists or has the wrong type.</dd>
   <dt>getSubField(std::string fieldName)</dt>
     <dd>
       Get a subField of a field.d
@@ -2353,6 +2350,9 @@ public:
       <br />
       <b>Note</b> The template version replaces getBooleanField, etc.<br/>
     </dd>
+  <dt>getSubFieldT(std::string const &amp;fieldName)</dt>
+     <dd>Like getSubField except that it throws std::runtime_error if
+       the field does not exists or has the wrong type.</dd>
   <dt>dumpValue</dt>
      <dd>Method for streams I/O.</dd>
 </dl>
@@ -5414,7 +5414,7 @@ public:
         raiseMonitor = true;
         if(pvFieldOptions!=NULL) {
             PVStringPtr pvString =
-                pvFieldOptions-&gt;getAs&lt;PVString&gt;("raiseMonitor");
+                pvFieldOptions-&gt;getSubField&lt;PVString&gt;("raiseMonitor");
                 if(pvString!=NULL) {
                     std::string value = pvString-&gt;get();
                     if(value.compare("false")==0) raiseMonitor = false;

--- a/documentation/pvDataCPP.html
+++ b/documentation/pvDataCPP.html
@@ -2309,8 +2309,15 @@ public:
     template&lt;typename PVT&gt;
     std::tr1::shared_ptr&lt;PVT&gt; getSubField(std::size_t fieldOffset) const
 
+    PVField&amp; getSubFieldT(std::string const &amp;fieldName) const;
+
     template&lt;typename PVT&gt;
-    PVT&amp; getSubFieldT(std::string const &amp;fieldName) const;
+    PVT&amp; getSubFieldT(std::string const &amp;fieldName) const
+
+    PVField&amp; getSubFieldT(std::size_t fieldOffset) const;
+
+    template&lt;typename PVT&gt;
+    PVT&amp; getSubFieldT(std::size_t fieldOffset) const
 
     virtual void serialize(
         ByteBuffer *pbuffer,SerializableControl *pflusher) const ;
@@ -2332,7 +2339,7 @@ public:
   <dt>getPVFields</dt>
     <dd>Returns the array of subfields. The set of subfields must all have
       different field names.</dd>
-  <dt>getSubField(std::string fieldName)</dt>
+  <dt>getSubField(std::string const &amp;fieldName)</dt>
     <dd>
       Get a subField of a field.d
       A non-null result is
@@ -2347,11 +2354,12 @@ public:
     <dd>Get the field located a fieldOffset, where fieldOffset is relative to
       the top level structure. This returns null if the specified field is not
       located within this PVStructure.
-      <br />
-      <b>Note</b> The template version replaces getBooleanField, etc.<br/>
     </dd>
   <dt>getSubFieldT(std::string const &amp;fieldName)</dt>
      <dd>Like getSubField except that it throws std::runtime_error if
+       the field does not exists or has the wrong type.</dd>
+  <dt>getSubFieldT(int fieldOffset)</dt>
+    <dd>Like getSubField except that it throws std::runtime_error if
        the field does not exists or has the wrong type.</dd>
   <dt>dumpValue</dt>
      <dd>Method for streams I/O.</dd>

--- a/documentation/pvDataCPP_20150623.html
+++ b/documentation/pvDataCPP_20150623.html
@@ -2309,15 +2309,15 @@ public:
     template&lt;typename PVT&gt;
     std::tr1::shared_ptr&lt;PVT&gt; getSubField(std::size_t fieldOffset) const
 
-    PVField&amp; getSubFieldT(std::string const &amp;fieldName) const;
+    PVFieldPtr getSubFieldT(std::string const &amp;fieldName) const;
 
     template&lt;typename PVT&gt;
-    PVT&amp; getSubFieldT(std::string const &amp;fieldName) const
+    std::tr1::shared_ptr&lt;PVT&gt; getSubFieldT(std::string const &amp;fieldName) const
 
-    PVField&amp; getSubFieldT(std::size_t fieldOffset) const;
+    PVFieldPtr getSubFieldT(std::size_t fieldOffset) const;
 
     template&lt;typename PVT&gt;
-    PVT&amp; getSubFieldT(std::size_t fieldOffset) const
+    std::tr1::shared_ptr&lt;PVT&gt; getSubFieldT(std::size_t fieldOffset) const
 
     virtual void serialize(
         ByteBuffer *pbuffer,SerializableControl *pflusher) const ;

--- a/documentation/pvDataCPP_20150623.html
+++ b/documentation/pvDataCPP_20150623.html
@@ -465,10 +465,10 @@ structure
     PVStructurePtr doubleValue = getPVDataCreate()-&gt;createPVStructure(
         getStandardField()-&gt;scalar(pvDouble,"alarm,timeStamp"));
     PVDoublePtr pvdouble =
-        doubleValue-&gt;getAs&lt;PVDouble&gt;("value");
+        doubleValue-&gt;getSubField&lt;PVDouble&gt;("value");
     pvdouble-&gt;put(1e5);
     cout &lt;&lt; *doubleValue &lt;&lt; endl;
-    double value = doubleValue-&gt;getAs&lt;PVDouble&gt;("value")-&gt;get();
+    double value = doubleValue-&gt;getSubField&lt;PVDouble&gt;("value")-&gt;get();
     cout &lt;&lt; "from get " &lt;&lt; value &lt;&lt; "\n\n";
 </pre>
 This produces:
@@ -491,7 +491,7 @@ from get 100000
     PVStructurePtr doubleArrayValue = pvDataCreate-&gt;createPVStructure(
         standardField-&gt;scalarArray(pvDouble,"alarm,timeStamp"));
     PVDoubleArrayPtr pvDoubleArray =
-         doubleArrayValue-&gt;getAs&lt;PVDoubleArray&gt;("value");
+         doubleArrayValue-&gt;getSubField&lt;PVDoubleArray&gt;("value");
     size_t len = 10;
     shared_vector&lt;double&gt; xxx(len);
     for(size_t i=0; i&lt; len; ++i) xxx[i] = i;
@@ -605,10 +605,10 @@ structure
                 createUnion(),
             "alarm,timeStamp"));
     PVStructurePtr pvTimeStamp =
-        pvStructure-&gt;getAs&lt;PVUnion&gt;("value")-&gt;select&lt;PVStructure&gt;(2);
-    pvTimeStamp-&gt;getAs&lt;PVLong&gt;("secondsPastEpoch")-&gt;put(1000);
+        pvStructure-&gt;getSubField&lt;PVUnion&gt;("value")-&gt;select&lt;PVStructure&gt;(2);
+    pvTimeStamp-&gt;getSubField&lt;PVLong&gt;("secondsPastEpoch")-&gt;put(1000);
     cout &lt;&lt; *pvStructure) &lt;&lt; "\n";
-    pvStructure-&gt;getAs&lt;PVUnion&gt;("value")-&gt;select&lt;PVDouble&gt;(0)-&gt;put(1e5);
+    pvStructure-&gt;getSubField&lt;PVUnion&gt;("value")-&gt;select&lt;PVDouble&gt;(0)-&gt;put(1e5);
     cout &lt;&lt; *pvStructure &lt;&lt; "\n\n";
 </pre>
 This produces:
@@ -648,13 +648,13 @@ epics:nt/NTUnion:1.0
         standardField-&gt;variantUnion("alarm,timeStamp"));
     PVStructurePtr pvTimeStamp =
         pvDataCreate-&gt;createPVStructure(standardField-&gt;timeStamp());
-    pvStructure-&gt;getAs&lt;PVUnion&gt;("value")-&gt;set(pvTimeStamp);
-    pvTimeStamp-&gt;getAs&lt;PVLong&gt;("secondsPastEpoch")-&gt;put(1000);
+    pvStructure-&gt;getSubField&lt;PVUnion&gt;("value")-&gt;set(pvTimeStamp);
+    pvTimeStamp-&gt;getSubField&lt;PVLong&gt;("secondsPastEpoch")-&gt;put(1000);
     cout &lt;&lt; *pvStructure &lt;&lt; "\n";
-    pvStructure-&gt;getAs&lt;PVUnion&gt;("value")-&gt;set(
+    pvStructure-&gt;getSubField&lt;PVUnion&gt;("value")-&gt;set(
         pvDataCreate-&gt;createPVScalar(pvDouble));
     PVDoublePtr pvValue = static_pointer_cast&lt;PVDouble&gt;(
-        pvStructure-&gt;getAs&lt;PVUnion&gt;("value")-&gt;get());
+        pvStructure-&gt;getSubField&lt;PVUnion&gt;("value")-&gt;get());
     pvValue-&gt;put(1e5);
     cout &lt;&lt; *pvStructure &lt;&lt; "\n\n";
 </pre>
@@ -718,7 +718,7 @@ epics:nt/NTUnion:1.0
     cout &lt;&lt; *pvStructure-&gt;getStructure() &lt;&lt; endl;
     cout &lt;&lt; "data\n";
     cout &lt;&lt; *pvStructure &lt;&lt; "\n";
-    PVUnionPtr pvUnion = pvStructure-&gt;getAs&lt;PVUnion&gt;("value");;
+    PVUnionPtr pvUnion = pvStructure-&gt;getSubField&lt;PVUnion&gt;("value");;
     pvUnion-&gt;select("doubleValue");
     PVDoublePtr pvDouble = pvUnion-&gt;get&lt;PVDouble&gt;();
     pvDouble-&gt;put(1.55);
@@ -726,7 +726,7 @@ epics:nt/NTUnion:1.0
     cout &lt;&lt; *pvStructure &lt;&lt; "\n";
     cout &lt;&lt; "value = " &lt;&lt; pvDouble-&gt;get() &lt;&lt; "\n";
     pvUnion-&gt;select("structValue");
-    pvDouble = pvUnion-&gt;get&lt;PVStructure&gt;()-&gt;getAs&lt;PVDouble&gt;("doubleValue");
+    pvDouble = pvUnion-&gt;get&lt;PVStructure&gt;()-&gt;getSubField&lt;PVDouble&gt;("doubleValue");
     pvDouble-&gt;put(1.65);
     cout &lt;&lt; "select structValue\n";
     cout &lt;&lt; *pvStructure &lt;&lt; "\n";
@@ -2304,13 +2304,13 @@ public:
     template&lt;typename PVT&gt;
     std::tr1::shared_ptr&lt;PVT&gt; getSubField(std::string const &amp;fieldName) const
 
-    template&lt;typename PVT&gt;
-    PVT&amp; getAs(const char *name) const;
-
     PVFieldPtr getSubField(std::size_t fieldOffset) const;
 
     template&lt;typename PVT&gt;
     std::tr1::shared_ptr&lt;PVT&gt; getSubField(std::size_t fieldOffset) const
+
+    template&lt;typename PVT&gt;
+    PVT&amp; getSubFieldT(std::string const &amp;fieldName) const;
 
     virtual void serialize(
         ByteBuffer *pbuffer,SerializableControl *pflusher) const ;
@@ -2332,9 +2332,6 @@ public:
   <dt>getPVFields</dt>
     <dd>Returns the array of subfields. The set of subfields must all have
       different field names.</dd>
-  <dt>getAs(const char *name)</dt>
-     <dd>Like the getSubField except that it throws std::runtime_error if
-       the field does not exists or has the wrong type.</dd>
   <dt>getSubField(std::string fieldName)</dt>
     <dd>
       Get a subField of a field.d
@@ -2353,6 +2350,9 @@ public:
       <br />
       <b>Note</b> The template version replaces getBooleanField, etc.<br/>
     </dd>
+  <dt>getSubFieldT(std::string const &amp;fieldName)</dt>
+     <dd>Like getSubField except that it throws std::runtime_error if
+       the field does not exists or has the wrong type.</dd>
   <dt>dumpValue</dt>
      <dd>Method for streams I/O.</dd>
 </dl>
@@ -5414,7 +5414,7 @@ public:
         raiseMonitor = true;
         if(pvFieldOptions!=NULL) {
             PVStringPtr pvString =
-                pvFieldOptions-&gt;getAs&lt;PVString&gt;("raiseMonitor");
+                pvFieldOptions-&gt;getSubField&lt;PVString&gt;("raiseMonitor");
                 if(pvString!=NULL) {
                     std::string value = pvString-&gt;get();
                     if(value.compare("false")==0) raiseMonitor = false;

--- a/documentation/pvDataCPP_20150623.html
+++ b/documentation/pvDataCPP_20150623.html
@@ -2309,8 +2309,15 @@ public:
     template&lt;typename PVT&gt;
     std::tr1::shared_ptr&lt;PVT&gt; getSubField(std::size_t fieldOffset) const
 
+    PVField&amp; getSubFieldT(std::string const &amp;fieldName) const;
+
     template&lt;typename PVT&gt;
-    PVT&amp; getSubFieldT(std::string const &amp;fieldName) const;
+    PVT&amp; getSubFieldT(std::string const &amp;fieldName) const
+
+    PVField&amp; getSubFieldT(std::size_t fieldOffset) const;
+
+    template&lt;typename PVT&gt;
+    PVT&amp; getSubFieldT(std::size_t fieldOffset) const
 
     virtual void serialize(
         ByteBuffer *pbuffer,SerializableControl *pflusher) const ;
@@ -2332,7 +2339,7 @@ public:
   <dt>getPVFields</dt>
     <dd>Returns the array of subfields. The set of subfields must all have
       different field names.</dd>
-  <dt>getSubField(std::string fieldName)</dt>
+  <dt>getSubField(std::string const &amp;fieldName)</dt>
     <dd>
       Get a subField of a field.d
       A non-null result is
@@ -2347,11 +2354,12 @@ public:
     <dd>Get the field located a fieldOffset, where fieldOffset is relative to
       the top level structure. This returns null if the specified field is not
       located within this PVStructure.
-      <br />
-      <b>Note</b> The template version replaces getBooleanField, etc.<br/>
     </dd>
   <dt>getSubFieldT(std::string const &amp;fieldName)</dt>
      <dd>Like getSubField except that it throws std::runtime_error if
+       the field does not exists or has the wrong type.</dd>
+  <dt>getSubFieldT(int fieldOffset)</dt>
+    <dd>Like getSubField except that it throws std::runtime_error if
        the field does not exists or has the wrong type.</dd>
   <dt>dumpValue</dt>
      <dd>Method for streams I/O.</dd>

--- a/src/factory/PVStructure.cpp
+++ b/src/factory/PVStructure.cpp
@@ -107,7 +107,7 @@ const PVFieldPtrArray & PVStructure::getPVFields() const
 
 PVFieldPtr  PVStructure::getSubField(string const &fieldName) const
 {
-    PVField * field = GetAsImpl(fieldName.c_str(), false);
+    PVField * field = getSubFieldImpl(fieldName.c_str(), false);
     if (field)
        return field->shared_from_this();
     else
@@ -134,7 +134,7 @@ PVFieldPtr  PVStructure::getSubField(size_t fieldOffset) const
     throw std::logic_error("PVStructure.getSubField: Logic error");
 }
 
-PVField* PVStructure::GetAsImpl(const char *name, bool throws) const
+PVField* PVStructure::getSubFieldImpl(const char *name, bool throws) const
 {
     const PVStructure *parent = this;
     if(!name)

--- a/src/factory/PVStructure.cpp
+++ b/src/factory/PVStructure.cpp
@@ -134,11 +134,11 @@ PVFieldPtr  PVStructure::getSubField(size_t fieldOffset) const
     throw std::logic_error("PVStructure.getSubField: Logic error");
 }
 
-PVField& PVStructure::getSubFieldT(std::size_t fieldOffset) const
+PVFieldPtr PVStructure::getSubFieldT(std::size_t fieldOffset) const
 {
-    PVField * raw = getSubField(fieldOffset).get();
-    if (raw)
-        return *raw;
+    PVFieldPtr pvField = getSubField(fieldOffset);
+    if (pvField.get())
+        return pvField;
     else
     {
         std::stringstream ss;

--- a/src/factory/PVStructure.cpp
+++ b/src/factory/PVStructure.cpp
@@ -140,17 +140,23 @@ PVField* PVStructure::GetAsImpl(const char *name, bool throws) const
     if(!name)
     {
         if (throws)
-            throw std::invalid_argument("field name is NULL string");
+            throw std::invalid_argument("Failed to get field: (Field name is NULL string)");
         else
             return NULL;
     }
+    const char *fullName = name;
     while(true) {
         const char *sep=name;
         while(*sep!='\0' && *sep!='.' && *sep!=' ') sep++;
         if(*sep==' ')
         {
             if (throws)
-                throw std::runtime_error("No spaces allowed in field name ");
+            {
+                std::stringstream ss;
+                ss << "Failed to get field: " << fullName
+                   << " (No spaces allowed in field name)";
+                throw std::runtime_error(ss.str());
+            }
             else
                 return NULL;
         }
@@ -158,7 +164,12 @@ PVField* PVStructure::GetAsImpl(const char *name, bool throws) const
         if(N==0)
         {
             if (throws)
-                throw std::runtime_error("zero-length field name encountered");
+            {
+                std::stringstream ss;
+                ss << "Failed to get field: " << fullName
+                   << " (Zero-length field name encountered)";
+                throw std::runtime_error(ss.str());
+            }
             else
                 return NULL;
         }
@@ -180,7 +191,12 @@ PVField* PVStructure::GetAsImpl(const char *name, bool throws) const
         if(!child)
         {
             if (throws)
-                throw std::runtime_error("field not found"); //TODO: which sub field?
+            {
+                std::stringstream ss;
+                ss << "Failed to get field: " << fullName << " ("
+                   << std::string(fullName, sep) << " not found)";
+                throw std::runtime_error(ss.str());   
+            }
             else
                 return NULL;
         }
@@ -191,7 +207,13 @@ PVField* PVStructure::GetAsImpl(const char *name, bool throws) const
             if(!parent)
             {
                 if (throws)
-                    throw std::runtime_error("mid-field is not a PVStructure"); //TODO: which sub field?
+                {
+                    std::stringstream ss;
+                    ss << "Failed to get field: " << fullName
+                       << " (" << std::string(fullName, sep)
+                       <<  " is not a structure)"; 
+                    throw std::runtime_error(ss.str());
+                }
                 else
                     return NULL;
             }

--- a/src/factory/PVStructure.cpp
+++ b/src/factory/PVStructure.cpp
@@ -107,11 +107,11 @@ const PVFieldPtrArray & PVStructure::getPVFields() const
 
 PVFieldPtr  PVStructure::getSubField(string const &fieldName) const
 {
-    try{
-        return GetAsImpl(fieldName.c_str())->shared_from_this();
-    }catch(...){
-        return PVFieldPtr();
-    }
+    PVField * field = GetAsImpl(fieldName.c_str(), false);
+    if (field)
+       return field->shared_from_this();
+    else
+       return PVFieldPtr();
 }
 
 
@@ -134,21 +134,34 @@ PVFieldPtr  PVStructure::getSubField(size_t fieldOffset) const
     throw std::logic_error("PVStructure.getSubField: Logic error");
 }
 
-PVField* PVStructure::GetAsImpl(const char *name) const
+PVField* PVStructure::GetAsImpl(const char *name, bool throws) const
 {
     const PVStructure *parent = this;
     if(!name)
-        throw std::invalid_argument("field name is NULL string");
-
+    {
+        if (throws)
+            throw std::invalid_argument("field name is NULL string");
+        else
+            return NULL;
+    }
     while(true) {
         const char *sep=name;
         while(*sep!='\0' && *sep!='.' && *sep!=' ') sep++;
         if(*sep==' ')
-            throw std::runtime_error("No spaces allowed in field name");
-
+        {
+            if (throws)
+                throw std::runtime_error("No spaces allowed in field name ");
+            else
+                return NULL;
+        }
         size_t N = sep-name;
         if(N==0)
-            throw std::runtime_error("zero-length field name encountered");
+        {
+            if (throws)
+                throw std::runtime_error("zero-length field name encountered");
+            else
+                return NULL;
+        }
 
         const PVFieldPtrArray& pvFields = parent->getPVFields();
 
@@ -165,13 +178,23 @@ PVField* PVStructure::GetAsImpl(const char *name) const
         }
 
         if(!child)
-            throw std::runtime_error("field not found"); //TODO: which sub field?
+        {
+            if (throws)
+                throw std::runtime_error("field not found"); //TODO: which sub field?
+            else
+                return NULL;
+        }
 
         if(*sep) {
             // this is not the requested leaf
             parent = dynamic_cast<PVStructure*>(child);
             if(!parent)
-                throw std::runtime_error("mid-field is not a PVStructure"); //TODO: which sub field?
+            {
+                if (throws)
+                    throw std::runtime_error("mid-field is not a PVStructure"); //TODO: which sub field?
+                else
+                    return NULL;
+            }
             child = NULL;
             name = sep+1; // skip past '.'
             // loop around to new parent
@@ -256,22 +279,13 @@ PVUnionPtr PVStructure::getUnionField(string const &fieldName)
 PVScalarArrayPtr PVStructure::getScalarArrayField(
     string const &fieldName,ScalarType elementType)
 {
-    try{
-        PVFieldPtr pvField = GetAsImpl(fieldName.c_str())->shared_from_this();
-        FieldConstPtr field = pvField->getField();
-        Type type = field->getType();
-        if(type!=scalarArray) {
-            return nullPVScalarArray;
-        }
-        ScalarArrayConstPtr pscalarArray
-            = static_pointer_cast<const ScalarArray>(pvField->getField());
-        if(pscalarArray->getElementType()!=elementType) {
-            return nullPVScalarArray;
-        }
-        return std::tr1::static_pointer_cast<PVScalarArray>(pvField);
-    }catch(...){
+     PVScalarArrayPtr arrayField = getSubField<PVScalarArray>(fieldName);
+     if (arrayField.get() &&
+         arrayField->getScalarArray()->getElementType()!=elementType)
+     {
         return nullPVScalarArray;
-    }
+     }
+     return arrayField;
 }
 
 PVStructureArrayPtr PVStructure::getStructureArrayField(

--- a/src/factory/PVStructure.cpp
+++ b/src/factory/PVStructure.cpp
@@ -134,6 +134,20 @@ PVFieldPtr  PVStructure::getSubField(size_t fieldOffset) const
     throw std::logic_error("PVStructure.getSubField: Logic error");
 }
 
+PVField& PVStructure::getSubFieldT(std::size_t fieldOffset) const
+{
+    PVField * raw = getSubField(fieldOffset).get();
+    if (raw)
+        return *raw;
+    else
+    {
+        std::stringstream ss;
+        ss << "Failed to get field with offset "
+           << fieldOffset << "(Invalid offset)" ;
+        throw std::runtime_error(ss.str());
+    }
+}
+
 PVField* PVStructure::getSubFieldImpl(const char *name, bool throws) const
 {
     const PVStructure *parent = this;

--- a/src/pv/pvData.h
+++ b/src/pv/pvData.h
@@ -729,7 +729,11 @@ public:
     {
         PVT *raw = dynamic_cast<PVT*>(GetAsImpl(name));
         if(!raw)
-            throw std::runtime_error("Field has wrong type");
+        {
+            std::stringstream ss;
+            ss << "Failed to get field: " << name << " (Field has wrong type)";
+            throw std::runtime_error(ss.str());
+        }
         return *raw;
     }
 

--- a/src/pv/pvData.h
+++ b/src/pv/pvData.h
@@ -712,7 +712,7 @@ public:
     }
 
 private:
-    PVField *GetAsImpl(const char *name, bool throws = true) const;
+    PVField *getSubFieldImpl(const char *name, bool throws = true) const;
 public:
 
     /**
@@ -721,13 +721,13 @@ public:
      * @returns A reference to the sub-field (never NULL)
      * @throws std::runtime_error if the requested sub-field doesn't exist, or has a different type
      * @code
-     *   PVInt& ref = pvStruct->getAs<PVInt>("substruct.leaffield");
+     *   PVInt& ref = pvStruct->getSubFieldT<PVInt>("substruct.leaffield");
      * @endcode
      */
     template<typename PVT>
-    PVT& getAs(const char *name) const
+    PVT& getSubFieldT(const char *name) const
     {
-        PVT *raw = dynamic_cast<PVT*>(GetAsImpl(name));
+        PVT *raw = dynamic_cast<PVT*>(getSubFieldImpl(name));
         if(!raw)
         {
             std::stringstream ss;
@@ -738,9 +738,9 @@ public:
     }
 
     template<typename PVT>
-    FORCE_INLINE PVT& getAs(std::string const &fieldName) const
+    FORCE_INLINE PVT& getSubFieldT(std::string const &fieldName) const
     {
-        return this->getAs<PVT>(fieldName.c_str());
+        return this->getSubFieldT<PVT>(fieldName.c_str());
     }
 
     /**

--- a/src/pv/pvData.h
+++ b/src/pv/pvData.h
@@ -736,9 +736,9 @@ public:
      * @returns A reference to the sub-field (never NULL)
      * @throws std::runtime_error if the requested sub-field doesn't exist, or has a different type
      */
-    FORCE_INLINE PVField& getSubFieldT(std::string const &fieldName) const
+    FORCE_INLINE PVFieldPtr getSubFieldT(std::string const &fieldName) const
     {
-        return *getSubFieldImpl(fieldName.c_str());
+        return getSubFieldImpl(fieldName.c_str())->shared_from_this();
     }
 
     /**
@@ -747,35 +747,37 @@ public:
      * @returns A reference to the sub-field (never NULL)
      * @throws std::runtime_error if the requested sub-field doesn't exist, or has a different type
      * @code
-     *   PVInt& ref = pvStruct->getSubFieldT<PVInt>("substruct.leaffield");
+     *   PVIntPtr ptr = pvStruct->getSubFieldT<PVInt>("substruct.leaffield");
      * @endcode
      */
     template<typename PVT>
-    FORCE_INLINE PVT& getSubFieldT(std::string const &fieldName) const
+    FORCE_INLINE std::tr1::shared_ptr<PVT> getSubFieldT(std::string const &fieldName) const
     {
         return this->getSubFieldT<PVT>(fieldName.c_str());
     }
 
     template<typename PVT>
-    PVT& getSubFieldT(const char *name) const
+    std::tr1::shared_ptr<PVT> getSubFieldT(const char *name) const
     {
-        PVT *raw = dynamic_cast<PVT*>(getSubFieldImpl(name));
-        if(!raw)
+        std::tr1::shared_ptr<PVT> pvField = std::tr1::dynamic_pointer_cast<PVT>(
+            getSubFieldImpl(name)->shared_from_this());
+
+        if (pvField.get())
+            return pvField;
+        else
         {
             std::stringstream ss;
             ss << "Failed to get field: " << name << " (Field has wrong type)";
             throw std::runtime_error(ss.str());
         }
-        return *raw;
     }
-
     /**
      * Get the subfield with the specified offset.
      * @param fieldOffset The offset.
      * @returns A reference to the sub-field (never NULL)
      * @throws std::runtime_error if the requested sub-field doesn't exist
      */
-    PVField& getSubFieldT(std::size_t fieldOffset) const;
+    PVFieldPtr getSubFieldT(std::size_t fieldOffset) const;
 
     /**
      * Get the subfield with the specified offset.
@@ -784,11 +786,12 @@ public:
      * @throws std::runtime_error if the requested sub-field doesn't exist, or has a different type 
      */
     template<typename PVT>
-    PVT& getSubFieldT(std::size_t fieldOffset) const
+    std::tr1::shared_ptr<PVT> getSubFieldT(std::size_t fieldOffset) const
     {
-        PVT* raw = dynamic_cast<PVT*>(&getSubFieldT(fieldOffset));
-        if (raw)
-            return *raw;
+        std::tr1::shared_ptr<PVT> pvField = std::tr1::dynamic_pointer_cast<PVT>(
+            getSubFieldT(fieldOffset));
+        if (pvField.get())
+            return pvField;
         else
         {
             std::stringstream ss;

--- a/src/pv/pvData.h
+++ b/src/pv/pvData.h
@@ -712,7 +712,7 @@ public:
     }
 
 private:
-    PVField *GetAsImpl(const char *name) const;
+    PVField *GetAsImpl(const char *name, bool throws = true) const;
 public:
 
     /**

--- a/testApp/pv/testPVData.cpp
+++ b/testApp/pv/testPVData.cpp
@@ -541,7 +541,7 @@ static void testFieldAccess()
     PVIntPtr a = fld->getSubField<PVInt>("test");
     testOk1(a!=NULL);
     if(a.get()) {
-        PVInt& b = fld->getAs<PVInt>("test");
+        PVInt& b = fld->getSubFieldT<PVInt>("test");
         testOk(&b==a.get(), "%p == %p", &b, a.get());
     } else
         testSkip(1, "test doesn't exist?");
@@ -549,7 +549,7 @@ static void testFieldAccess()
     a = fld->getSubField<PVInt>("hello.world");
     testOk1(a!=NULL);
     if(a.get()) {
-        PVInt& b = fld->getAs<PVInt>("hello.world");
+        PVInt& b = fld->getSubFieldT<PVInt>("hello.world");
         testOk(&b==a.get(), "%p == %p", &b, a.get());
     } else
         testSkip(1, "hello.world doesn't exist?");
@@ -579,7 +579,7 @@ static void testFieldAccess()
     // null string
     try{
         char * name = NULL;
-        fld->getAs<PVInt>(name);
+        fld->getSubFieldT<PVInt>(name);
         testFail("missing required exception");
     }catch(std::invalid_argument& e){
         testPass("caught expected exception: %s", e.what());
@@ -587,7 +587,7 @@ static void testFieldAccess()
 
     // non-existent
     try{
-        fld->getAs<PVInt>("invalid");
+        fld->getSubFieldT<PVInt>("invalid");
         testFail("missing required exception");
     }catch(std::runtime_error& e){
         testPass("caught expected exception: %s", e.what());
@@ -595,7 +595,7 @@ static void testFieldAccess()
 
     // wrong type
     try{
-        fld->getAs<PVDouble>("test");
+        fld->getSubFieldT<PVDouble>("test");
         testFail("missing required exception");
     }catch(std::runtime_error& e){
         testPass("caught expected exception: %s", e.what());
@@ -603,7 +603,7 @@ static void testFieldAccess()
 
     // empty leaf field name
     try{
-        fld->getAs<PVDouble>("hello.");
+        fld->getSubFieldT<PVDouble>("hello.");
         testFail("missing required exception");
     }catch(std::runtime_error& e){
         testPass("caught expected exception: %s", e.what());
@@ -611,13 +611,13 @@ static void testFieldAccess()
 
     // empty field name
     try{
-        fld->getAs<PVDouble>("hello..world");
+        fld->getSubFieldT<PVDouble>("hello..world");
         testFail("missing required exception");
     }catch(std::runtime_error& e){
         testPass("caught expected exception: %s", e.what());
     }
     try{
-        fld->getAs<PVDouble>(".");
+        fld->getSubFieldT<PVDouble>(".");
         testFail("missing required exception");
     }catch(std::runtime_error& e){
         testPass("caught expected exception: %s", e.what());
@@ -625,7 +625,7 @@ static void testFieldAccess()
 
     // whitespace
     try{
-        fld->getAs<PVDouble>(" test");
+        fld->getSubFieldT<PVDouble>(" test");
         testFail("missing required exception");
     }catch(std::runtime_error& e){
         testPass("caught expected exception: %s", e.what());
@@ -633,7 +633,7 @@ static void testFieldAccess()
 
     // intermediate field not structure
     try{
-        fld->getAs<PVDouble>("hello.world.invalid");
+        fld->getSubFieldT<PVDouble>("hello.world.invalid");
         testFail("missing required exception");
     }catch(std::runtime_error& e){
         testPass("caught expected exception: %s", e.what());

--- a/testApp/pv/testPVData.cpp
+++ b/testApp/pv/testPVData.cpp
@@ -573,6 +573,19 @@ static void testFieldAccess()
     // whitespace
     testOk1(fld->getSubField<PVInt>(" test").get()==NULL);
 
+    // intermediate field not structure
+    testOk1(fld->getSubField<PVInt>("hello.world.invalid").get()==NULL);
+
+    // null string
+    try{
+        char * name = NULL;
+        fld->getAs<PVInt>(name);
+        testFail("missing required exception");
+    }catch(std::invalid_argument& e){
+        testPass("caught expected exception: %s", e.what());
+    }
+
+    // non-existent
     try{
         fld->getAs<PVInt>("invalid");
         testFail("missing required exception");
@@ -580,6 +593,7 @@ static void testFieldAccess()
         testPass("caught expected exception: %s", e.what());
     }
 
+    // wrong type
     try{
         fld->getAs<PVDouble>("test");
         testFail("missing required exception");
@@ -587,6 +601,37 @@ static void testFieldAccess()
         testPass("caught expected exception: %s", e.what());
     }
 
+    // empty leaf field name
+    try{
+        fld->getAs<PVDouble>("hello.");
+        testFail("missing required exception");
+    }catch(std::runtime_error& e){
+        testPass("caught expected exception: %s", e.what());
+    }
+
+    // empty field name
+    try{
+        fld->getAs<PVDouble>("hello..world");
+        testFail("missing required exception");
+    }catch(std::runtime_error& e){
+        testPass("caught expected exception: %s", e.what());
+    }
+    try{
+        fld->getAs<PVDouble>(".");
+        testFail("missing required exception");
+    }catch(std::runtime_error& e){
+        testPass("caught expected exception: %s", e.what());
+    }
+
+    // whitespace
+    try{
+        fld->getAs<PVDouble>(" test");
+        testFail("missing required exception");
+    }catch(std::runtime_error& e){
+        testPass("caught expected exception: %s", e.what());
+    }
+
+    // intermediate field not structure
     try{
         fld->getAs<PVDouble>("hello.world.invalid");
         testFail("missing required exception");
@@ -597,7 +642,7 @@ static void testFieldAccess()
 
 MAIN(testPVData)
 {
-    testPlan(236);
+    testPlan(242);
     fieldCreate = getFieldCreate();
     pvDataCreate = getPVDataCreate();
     standardField = getStandardField();

--- a/testApp/pv/testPVData.cpp
+++ b/testApp/pv/testPVData.cpp
@@ -541,16 +541,16 @@ static void testFieldAccess()
     PVIntPtr a = fld->getSubField<PVInt>("test");
     testOk1(a!=NULL);
     if(a.get()) {
-        PVInt& b = fld->getSubFieldT<PVInt>("test");
-        testOk(&b==a.get(), "%p == %p", &b, a.get());
+        PVIntPtr b = fld->getSubFieldT<PVInt>("test");
+        testOk(b.get()==a.get(), "%p == %p", b.get(), a.get());
     } else
         testSkip(1, "test doesn't exist?");
 
     a = fld->getSubField<PVInt>("hello.world");
     testOk1(a!=NULL);
     if(a.get()) {
-        PVInt& b = fld->getSubFieldT<PVInt>("hello.world");
-        testOk(&b==a.get(), "%p == %p", &b, a.get());
+        PVIntPtr b = fld->getSubFieldT<PVInt>("hello.world");
+        testOk(b.get()==a.get(), "%p == %p", b.get(), a.get());
     } else
         testSkip(1, "hello.world doesn't exist?");
 


### PR DESCRIPTION
API proposal to replace getAs introduced in https://github.com/epics-base/pvDataCPP/pull/4 with throwing version of getSubField called getSubFieldT as per the AI assigned to me in the EPICS V4 working group meeting 20150630.

Summary of changes:
<ol>
<li>getSubField implemented without throwing and catching an exception</li>
<li>Exception messages improved</li>
<li>Unit tests added</li>
<li>getAs renamed getSubFieldT</li>
<li>Make overloads of getSubField and getSubFieldT match</li>
<li>getSubFieldT returns a shared_ptr instead of a reference.</li>
</ol>
<p>Each of these have been done as a separate commit. <p>

<p>(Note the bug in getAs implementation was fixed in master first.)<p>
<ol>
<li>The getAs pull request  https://github.com/epics-base/pvDataCPP/pull/4 implemented getSubField by throwing an exception when a field was not found, catching it and returning null. This is inefficient,both because of throwing and catching the exception and constructing the exception message, and unnecessary. Note getSubField returning null is not necessarily an error as this will occur frequently with optional fields. The new implementation just returns null in this case without throwing.</li>

<li>The getAs exception messages are now a bit more meaningful
With the following structure
<pre>
structure 
    double value
    time_t timeStamp
        long secondsPastEpoch
        int nanoseconds
        int userTag
</pre>
</li>
the following code (shown with API changes) produces run_time exceptions with the following messages:
<pre>
pvs->getSubFieldT<PVInt>("value")->put(42);
runtime_error: Failed to get field: value (Field has wrong type)

pvs->getSubFieldT<PVDouble>("x")->put(3.14);
runtime_error: Failed to get field: x (x not found)

pvs->getSubFieldT<PVInt>("x.userTag")->put(42)
runtime_error: Failed to get field: x.userTag (x not found)

pvs->getSubFieldT<PVInt>("timeStamp.x")->put(42)
runtime_error: Failed to get field: timeStamp.x (timeStamp.x not found)

pvs->getSubFieldT<PVInt>("timeStamp.userTag.y")->put(42)
runtime_error: Failed to get field: timeStamp.userTag.y (timeStamp.userTag is not a structure)

pvs->getSubFieldT("timeStamp..")->put(3.14)
runtime_error: Failed to get field: timeStamp.. (Zero-length field name encountered)
</pre>
<li>Unit tests

The coverage of the test cases for getSubField and getAs/getSubFieldT has been increased.</li>

<li>getAs has been renamed getSubFieldT to indicate the behaviour is as getSubField except it throws, as discussed in the meeting.</li>

<li>After the getAs pull request getSubField had template and non-template functions taking a string or an offset, whereas getAs took a c-string or string. The appropriate functions have been added so for every getSubField there is a getSubFieldT and vice versa. There could be some rationalisation here - if we deprecate the non-template getSubField then we don't need the non-template getSubFieldT.</li>

<li>The getSubFieldT functions now return a shared_ptr, guaranteed not null. Tests and documentation have been updated. This has been done last in case we decide to retain returning references.</li>
</ol>