### PR TITLE
Replace calls of deprecated PVStructure::getScalarArrayField

### DIFF
--- a/src/factory/StandardPVField.cpp
+++ b/src/factory/StandardPVField.cpp
@@ -66,11 +66,9 @@ PVStructurePtr StandardPVField::enumerated(StringArray const &choices)
 {
     StructureConstPtr field = standardField->enumerated();
     PVStructurePtr pvStructure = pvDataCreate->createPVStructure(field);
-    PVScalarArrayPtr pvScalarArray = pvStructure->getScalarArrayField(
-        "choices",pvString);
     PVStringArray::svector cdata(choices.size());
     std::copy(choices.begin(), choices.end(), cdata.begin());
-    static_cast<PVStringArray&>(*pvScalarArray).replace(freeze(cdata));
+    pvStructure->getSubField<PVStringArray>("choices")->replace(freeze(cdata));
     return pvStructure;
 }
 
@@ -79,11 +77,9 @@ PVStructurePtr StandardPVField::enumerated(
 {
     StructureConstPtr field = standardField->enumerated(properties);
     PVStructurePtr pvStructure =  pvDataCreate->createPVStructure(field);
-    PVScalarArrayPtr pvScalarArray = pvStructure->getScalarArrayField(
-        "value.choices",pvString);
     PVStringArray::svector cdata(choices.size());
     std::copy(choices.begin(), choices.end(), cdata.begin());
-    static_cast<PVStringArray&>(*pvScalarArray).replace(freeze(cdata));
+    pvStructure->getSubField<PVStringArray>("value.choices")->replace(freeze(cdata));
     return pvStructure;
 }
 

--- a/src/property/pvEnumerated.cpp
+++ b/src/property/pvEnumerated.cpp
@@ -30,13 +30,12 @@ bool PVEnumerated::attach(PVFieldPtr const & pvField)
     PVStructurePtr pvStructure = static_pointer_cast<PVStructure>(pvField);
     pvIndex = pvStructure->getSubField<PVInt>("index");
     if(pvIndex.get()==NULL) return false;
-    PVScalarArrayPtr pvScalarArray = pvStructure->getScalarArrayField(
-        "choices",pvString);
-    if(pvScalarArray.get()==NULL) {
+    PVStringArrayPtr pvStringArray = pvStructure->getSubField<PVStringArray>("choices");
+    if(pvStringArray.get()==NULL) {
         pvIndex.reset();
         return false;
     }
-    pvChoices = static_pointer_cast<PVStringArray>(pvScalarArray);
+    pvChoices = pvStringArray;
     return true;
 }
 

--- a/src/pv/pvData.h
+++ b/src/pv/pvData.h
@@ -908,7 +908,7 @@ public:
      * @return Pointer to the field of null if a field with that name and type does not exist.
      */
     PVScalarArrayPtr getScalarArrayField(
-        std::string const &fieldName,ScalarType elementType);
+        std::string const &fieldName,ScalarType elementType) USAGE_DEPRECATED;
     /**
      * Get a structureArray field with the specified name.
      * @deprecated No longer needed. Use template version of getSubField

--- a/testApp/copy/testPVCopy.cpp
+++ b/testApp/copy/testPVCopy.cpp
@@ -108,7 +108,6 @@ static void testPVScalar(
 }
 
 static void testPVScalarArray(
-    ScalarType scalarType,
     string const & valueNameMaster,
     string const & valueNameCopy,
     PVStructurePtr const & pvMaster,
@@ -256,7 +255,7 @@ static void arrayTest()
     if(debug) { cout << "pvRequest\n" << *pvRequest << endl; }
     pvCopy = PVCopy::create(pvMaster,pvRequest,"");
     valueNameCopy = "value";
-    testPVScalarArray(pvDouble,valueNameMaster,valueNameCopy,pvMaster,pvCopy);
+    testPVScalarArray(valueNameMaster,valueNameCopy,pvMaster,pvCopy);
     request = "";
     valueNameMaster = "value";
     pvRequest = createRequest->createRequest(request);
@@ -264,7 +263,7 @@ static void arrayTest()
     if(debug) { cout << "pvRequest\n" << *pvRequest << endl; }
     pvCopy = PVCopy::create(pvMaster,pvRequest,"");
     valueNameCopy = "value";
-    testPVScalarArray(pvDouble,valueNameMaster,valueNameCopy,pvMaster,pvCopy);
+    testPVScalarArray(valueNameMaster,valueNameCopy,pvMaster,pvCopy);
     request = "alarm,timeStamp,value";
     valueNameMaster = "value";
     pvRequest = createRequest->createRequest(request);
@@ -272,7 +271,7 @@ static void arrayTest()
     if(debug) { cout << "pvRequest\n" << *pvRequest << endl; }
     pvCopy = PVCopy::create(pvMaster,pvRequest,"");
     valueNameCopy = "value";
-    testPVScalarArray(pvDouble,valueNameMaster,valueNameCopy,pvMaster,pvCopy);
+    testPVScalarArray(valueNameMaster,valueNameCopy,pvMaster,pvCopy);
 }
 
 static PVStructurePtr createPowerSupply()

--- a/testApp/copy/testPVCopy.cpp
+++ b/testApp/copy/testPVCopy.cpp
@@ -123,14 +123,14 @@ static void testPVScalarArray(
     shared_vector<double> values(n);
     shared_vector<const double> cvalues;
 
-    pvValueMaster = pvMaster->getScalarArrayField(valueNameMaster,scalarType);
+    pvValueMaster = pvMaster->getSubField<PVScalarArray>(valueNameMaster);
     for(size_t i=0; i<n; i++) values[i] = i;
     const shared_vector<const double> xxx(freeze(values));
     pvValueMaster->putFrom(xxx);
     StructureConstPtr structure = pvCopy->getStructure();
     if(debug) { cout << "structure from copy" << endl << *structure << endl;}
     pvStructureCopy = pvCopy->createPVStructure();
-    pvValueCopy = pvStructureCopy->getScalarArrayField(valueNameCopy,scalarType);
+    pvValueCopy = pvStructureCopy->getSubField<PVScalarArray>(valueNameCopy);
     bitSet = BitSetPtr(new BitSet(pvStructureCopy->getNumberFields()));
     pvCopy->initCopy(pvStructureCopy, bitSet);
     if(debug) { cout << "after initCopy pvValueCopy " << *pvValueCopy << endl; }

--- a/testApp/pv/testOperators.cpp
+++ b/testApp/pv/testOperators.cpp
@@ -76,7 +76,7 @@ MAIN(testOperators)
     
     PVDoubleArray::svector values(3);
     values[0] = 1.1; values[1] = 2.2; values[2] = 3.3;
-    PVDoubleArrayPtr darray = std::tr1::dynamic_pointer_cast<PVDoubleArray>(pvStructure->getScalarArrayField("value", pvDouble));
+    PVDoubleArrayPtr darray = pvStructure->getSubField<PVDoubleArray>("value");
     darray->replace(freeze(values));
     std::cout << *darray << std::endl;
     std::cout << format::array_at(1) << *darray << std::endl;

--- a/testApp/pv/testPVData.cpp
+++ b/testApp/pv/testPVData.cpp
@@ -328,8 +328,7 @@ static void testScalarArrayCommon(string /*fieldName*/,ScalarType stype)
 {
     PVStructurePtr pvStructure = standardPVField->scalarArray(
         stype,alarmTimeStamp);
-    PVScalarArrayPtr scalarArray = pvStructure->getScalarArrayField(
-        "value",stype);
+    PVScalarArrayPtr scalarArray = pvStructure->getSubField<PVScalarArray>("value");
     testOk1(scalarArray.get()!=0);
     if(stype==pvBoolean) {
         StringArray values(3);


### PR DESCRIPTION
<p>Calls of the deprecated function PVStructure::getScalarArrayField have been replace by calls of the template function PVStructure::getSubField.
</p>

<p>getScalarArrayField  is now declared using the USAGE_DEPRECATED macro.</p> 