### PR TITLE
Fix build problem on Mac

### DIFF
--- a/testApp/pv/testPVData.cpp
+++ b/testApp/pv/testPVData.cpp
@@ -538,7 +538,7 @@ static void testFieldAccess()
     PVStructurePtr fld = pvDataCreate->createPVStructure(tdef);
 
     PVIntPtr a = fld->getSubField<PVInt>("test");
-    testOk1(a!=NULL);
+    testOk1(a.get() != NULL);
     if(a.get()) {
         PVIntPtr b = fld->getSubFieldT<PVInt>("test");
         testOk(b.get()==a.get(), "%p == %p", b.get(), a.get());
@@ -546,7 +546,7 @@ static void testFieldAccess()
         testSkip(1, "test doesn't exist?");
 
     a = fld->getSubField<PVInt>("hello.world");
-    testOk1(a!=NULL);
+    testOk1(a.get() != NULL);
     if(a.get()) {
         PVIntPtr b = fld->getSubFieldT<PVInt>("hello.world");
         testOk(b.get()==a.get(), "%p == %p", b.get(), a.get());


### PR DESCRIPTION
```
../../testApp/pv/testPVData.cpp:549:14: error: use of overloaded operator '!='
      is ambiguous (with operand types 'PVIntPtr' (aka 'shared_ptr<PVInt>') and
      'long')
    testOk1(a!=NULL);
            ~^ ~~~~
```

If there's a better (more standard C++) solution I'd be happy to hear it.