### PR TITLE
add serializeToVector()

### DIFF
--- a/src/misc/serialize.h
+++ b/src/misc/serialize.h
@@ -167,13 +167,19 @@ namespace epics { namespace pvData {
     /**
      * @brief deserializeFromBuffer Deserialize into S from provided vector
      * @param S A Serializeable object.  The current contents will be replaced
-     * @param byteOrder Byte order to write (EPICS_ENDIAN_LITTLE or EPICS_ENDIAN_BIG)
      * @param in The input buffer (byte order of this buffer is used)
      * @throws std::logic_error if input buffer is too small.  State of S is then undefined.
      */
     void deserializeFromBuffer(Serializable *S,
                                ByteBuffer& in);
 
+    /**
+     * @brief deserializeFromBuffer Deserialize into S from provided vector
+     * @param S A Serializeable object.  The current contents will be replaced
+     * @param byteOrder Byte order to write (EPICS_ENDIAN_LITTLE or EPICS_ENDIAN_BIG)
+     * @param in The input vector
+     * @throws std::logic_error if input buffer is too small.  State of S is then undefined.
+     */
     inline void deserializeFromVector(Serializable *S,
                                       int byteOrder,
                                       const std::vector<epicsUInt8>& in)

--- a/src/misc/serialize.h
+++ b/src/misc/serialize.h
@@ -165,6 +165,24 @@ namespace epics { namespace pvData {
                            std::vector<epicsUInt8>& out);
 
     /**
+     * @brief deserializeFromBuffer Deserialize into S from provided vector
+     * @param S A Serializeable object.  The current contents will be replaced
+     * @param byteOrder Byte order to write (EPICS_ENDIAN_LITTLE or EPICS_ENDIAN_BIG)
+     * @param in The input buffer (byte order of this buffer is used)
+     * @throws std::logic_error if input buffer is too small.  State of S is then undefined.
+     */
+    void deserializeFromBuffer(Serializable *S,
+                               ByteBuffer& in);
+
+    inline void deserializeFromVector(Serializable *S,
+                                      int byteOrder,
+                                      const std::vector<epicsUInt8>& in)
+    {
+        ByteBuffer B((char*)&in[0], in.size(), byteOrder); // we promise not the modify 'in'
+        deserializeFromBuffer(S, B);
+    }
+
+    /**
      * @brief Class for serializing bitSets.
      *
      */

--- a/src/misc/serialize.h
+++ b/src/misc/serialize.h
@@ -10,6 +10,8 @@
 #ifndef SERIALIZE_H
 #define SERIALIZE_H
 
+#include <epicsTypes.h>
+
 #include <pv/byteBuffer.h>
 #include <pv/sharedPtr.h>
 
@@ -150,6 +152,17 @@ namespace epics { namespace pvData {
             DeserializableControl *flusher) = 0;
     };
 
+    /**
+     * @brief Push serialize and append to the provided byte vector.
+     * No caching is done.  Only complete serialization.
+     *
+     * @param S A Serializable object
+     * @param byteOrder Byte order to write (EPICS_ENDIAN_LITTLE or EPICS_ENDIAN_BIG)
+     * @param out The output vector.  Results are appended
+     */
+    void serializeToVector(const Serializable *S,
+                           int byteOrder,
+                           std::vector<epicsUInt8>& out);
 
     /**
      * @brief Class for serializing bitSets.

--- a/src/misc/serializeHelper.cpp
+++ b/src/misc/serializeHelper.cpp
@@ -14,6 +14,7 @@
 
 #define epicsExportSharedSymbols
 #include <pv/pvType.h>
+#include <pv/byteBuffer.h>
 #include <pv/epicsException.h>
 #include <pv/byteBuffer.h>
 #include <pv/serializeHelper.h>
@@ -139,6 +140,78 @@ namespace epics {
             else
                 return emptyStringtring;
         }
+    }
+}
 
+namespace {
+using namespace epics::pvData;
+
+struct ToString : public epics::pvData::SerializableControl
+{
+    typedef std::vector<epicsUInt8> buf_type;
+    buf_type buf;
+    buf_type& out;
+    ByteBuffer bufwrap;
+
+    ToString(buf_type& out, int byteOrder = EPICS_BYTE_ORDER)
+        :buf(16*1024)
+        ,out(out)
+        ,bufwrap((char*)&buf[0], buf.size(), byteOrder)
+    {}
+
+    virtual void flushSerializeBuffer()
+    {
+        size_t N = out.size();
+        out.resize(out.size()+bufwrap.getPosition());
+        std::copy(buf.begin(),
+                  buf.begin()+bufwrap.getPosition(),
+                  out.begin()+N);
+        bufwrap.clear();
+    }
+
+    virtual void ensureBuffer(std::size_t size)
+    {
+        flushSerializeBuffer();
+        assert(bufwrap.getRemaining()>0);
+    }
+
+    virtual void alignBuffer(std::size_t alignment)
+    {
+        if(bufwrap.getRemaining()<alignment)
+            flushSerializeBuffer();
+        assert(bufwrap.getRemaining()>=alignment);
+        bufwrap.align(alignment);
+    }
+
+    virtual bool directSerialize(
+        ByteBuffer *existingBuffer,
+        const char* toSerialize,
+        std::size_t elementCount,
+        std::size_t elementSize)
+    {
+        return false;
+    }
+
+    virtual void cachedSerialize(
+        std::tr1::shared_ptr<const Field> const & field,
+        ByteBuffer* buffer)
+    {
+        field->serialize(buffer, this);
+    }
+};
+
+} // namespace
+
+namespace epics {
+    namespace pvData {
+        void serializeToVector(const Serializable *S,
+                               int byteOrder,
+                               std::vector<epicsUInt8>& out)
+        {
+            ToString TS(out, byteOrder);
+            S->serialize(&TS.bufwrap, &TS);
+            TS.flushSerializeBuffer();
+            assert(TS.bufwrap.getPosition()==0);
+        }
     }
 }


### PR DESCRIPTION
serializeToVector() takes an arbitrary subclass of Serializable to do so, with the results placed in a byte array (vector<char>).  No type information caching is performed as the code to do this is presently in pvAccessCPP.

I wrote serializeToVector() for the new gateway to provide a key for a lookup table to de-duplicate requests having idential pvrequest blobs.  I was concerned that, while operator< could be implemented for PVStructure for use with key std::map, this wouldn't be efficient.  This would be the ideal situation for a hash table, but PVField sub-classes also doesn't define a hash function, and I can't easily use std::unordered_map anyway.

While this code began like as a workaround, I think it can function as a useful example of operating on Serialization.  If it isn't accepted here I'll pull it into the gateway.