### PR TITLE
set SHRLIB_VERSION for libpvData.so

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -28,3 +28,5 @@ USR_CPPFLAGS += --coverage
 USR_LDFLAGS += --coverage
 endif
 
+# shared library ABI version.
+SHRLIB_VERSION ?= 5.0

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -28,5 +28,3 @@ USR_CPPFLAGS += --coverage
 USR_LDFLAGS += --coverage
 endif
 
-# shared library ABI version.
-SHRLIB_VERSION ?= 5.0

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,5 +20,8 @@ LIBRARY = pvData
 
 pvData_LIBS += Com
 
+# shared library ABI version.
+SHRLIB_VERSION ?= 5.0
+
 include $(TOP)/configure/RULES
 


### PR DESCRIPTION
Include the module version in the SONAME ("libpvData.so.5.0" atm.).  pvData_LIBS is already being set correctly w/ libCom.  Others are added by Base/gcc.

> $ readelf -d lib/linux-x86_64-debug/libpvData.so |egrep 'NEEDED|SONAME'
>  0x0000000000000001 (NEEDED)             Shared library: [libCom.so.3.16.0]
>  0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
>  0x0000000000000001 (NEEDED)             Shared library: [libreadline.so.6]
>  0x0000000000000001 (NEEDED)             Shared library: [librt.so.1]
>  0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
>  0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
>  0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
>  0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
>  0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
>  0x000000000000000e (SONAME)             Library soname: [libpvData.so.5.0]