### PR TITLE
getSubField -> getSubFieldT to avoid potential NULL de-ref.

### DIFF
--- a/src/copy/pvCopy.cpp
+++ b/src/copy/pvCopy.cpp
@@ -348,7 +348,7 @@ bool PVCopy::init(epics::pvData::PVStructurePtr const &pvRequest)
     if(len==string::npos) entireMaster = true;
     if(len==0) entireMaster = true;
     PVStructurePtr pvOptions;
-    if(len==1 && pvRequest->getSubField<PVStructure>("_options")) {
+    if(len==1) {
         pvOptions = pvRequest->getSubField<PVStructure>("_options");
     }
     if(entireMaster) {

--- a/src/copy/pvCopy.cpp
+++ b/src/copy/pvCopy.cpp
@@ -348,7 +348,7 @@ bool PVCopy::init(epics::pvData::PVStructurePtr const &pvRequest)
     if(len==string::npos) entireMaster = true;
     if(len==0) entireMaster = true;
     PVStructurePtr pvOptions;
-    if(len==1 && pvRequest->getSubField("_options")) {
+    if(len==1 && pvRequest->getSubField<PVStructure>("_options")) {
         pvOptions = pvRequest->getSubField<PVStructure>("_options");
     }
     if(entireMaster) {
@@ -441,8 +441,7 @@ CopyNodePtr PVCopy::createStructureNodes(
         PVFieldPtr copyPVField = copyPVFields[i];
         string fieldName = copyPVField->getFieldName();
         
-        PVStructurePtr requestPVStructure = static_pointer_cast<PVStructure>(
-              pvFromRequest->getSubField(fieldName));
+        PVStructurePtr requestPVStructure = pvFromRequest->getSubField<PVStructure>(fieldName);
         PVStructurePtr pvSubFieldOptions;
         PVFieldPtr pvField = requestPVStructure->getSubField("_options");
         if(pvField) pvSubFieldOptions = static_pointer_cast<PVStructure>(pvField);
@@ -551,7 +550,7 @@ void PVCopy::updateStructureNodeFromBitSet(
     CopyNodePtrArrayPtr  nodes = structureNode->nodes;
     for(size_t i=0; i<nodes->size(); i++) {
         CopyNodePtr node = (*nodes)[i];
-        PVFieldPtr pvField = pvCopy->getSubField(node->structureOffset);
+        PVFieldPtr pvField = pvCopy->getSubFieldT(node->structureOffset);
         if(node->isStructure) {
             PVStructurePtr xxx = static_pointer_cast<PVStructure>(pvField);
             CopyStructureNodePtr subStructureNode =

--- a/src/factory/StandardPVField.cpp
+++ b/src/factory/StandardPVField.cpp
@@ -68,7 +68,7 @@ PVStructurePtr StandardPVField::enumerated(StringArray const &choices)
     PVStructurePtr pvStructure = pvDataCreate->createPVStructure(field);
     PVStringArray::svector cdata(choices.size());
     std::copy(choices.begin(), choices.end(), cdata.begin());
-    pvStructure->getSubField<PVStringArray>("choices")->replace(freeze(cdata));
+    pvStructure->getSubFieldT<PVStringArray>("choices")->replace(freeze(cdata));
     return pvStructure;
 }
 
@@ -79,7 +79,7 @@ PVStructurePtr StandardPVField::enumerated(
     PVStructurePtr pvStructure =  pvDataCreate->createPVStructure(field);
     PVStringArray::svector cdata(choices.size());
     std::copy(choices.begin(), choices.end(), cdata.begin());
-    pvStructure->getSubField<PVStringArray>("value.choices")->replace(freeze(cdata));
+    pvStructure->getSubFieldT<PVStringArray>("value.choices")->replace(freeze(cdata));
     return pvStructure;
 }
 

--- a/src/pvMisc/bitSetUtil.cpp
+++ b/src/pvMisc/bitSetUtil.cpp
@@ -38,7 +38,7 @@ static bool checkBitSetPVField(
     PVStructurePtr pvStructure = static_pointer_cast<PVStructure>(pvField);
     offset = static_cast<int32>(pvStructure->getFieldOffset()) + 1;
     while(offset<initialOffset + nbits) {
-        PVFieldPtr pvSubField = pvStructure->getSubField(offset);
+        PVFieldPtr pvSubField = pvStructure->getSubFieldT(offset);
         int32 nbitsNow = static_cast<int32>(pvSubField->getNumberFields());
         if(nbitsNow==1) {
             if(bitSet->get(offset)) {


### PR DESCRIPTION
Fix a couple of instances where the return values of getSubField() is dereferenced w/o checking for NULL.  Also close a logic hole in pvCopy.

@mrkraimer I only make a cursory search for the most obvious cases where getSubField() is mis-used.  I strongly suspect that there are more in pvCopy.cpp which are masked by the use of utility functions.