### PR TITLE
Fix shared_vector<>

### DIFF
--- a/src/misc/pv/sharedVector.h
+++ b/src/misc/pv/sharedVector.h
@@ -553,7 +553,11 @@ class shared_vector<E, typename meta::is_void<E>::type >
 {
     typedef detail::shared_vector_base<E> base_t;
     ScalarType m_vtype;
+
+    // allow specialization for all E to be friends
+    template<typename E1, class Enable1> friend class shared_vector;
 public:
+    typedef E value_type;
     typedef E* pointer;
     typedef ptrdiff_t difference_type;
     typedef size_t size_type;

--- a/src/misc/pv/sharedVector.h
+++ b/src/misc/pv/sharedVector.h
@@ -575,12 +575,12 @@ public:
 
     shared_vector(shared_vector<void>& O,
                   detail::_shared_vector_freeze_tag t)
-        :base_t(O,t)
+        :base_t(O,t), m_vtype(O.m_vtype)
     {}
 
     shared_vector(shared_vector<const void>& O,
                   detail::_shared_vector_thaw_tag t)
-        :base_t(O,t)
+        :base_t(O,t), m_vtype(O.m_vtype)
     {}
 
     shared_vector& operator=(const shared_vector& o)
@@ -692,7 +692,7 @@ namespace detail {
             return shared_vector<TO>(src, detail::_shared_vector_cast_tag());
         }
     };
-    
+
     // convert from void uses original type or throws an exception.
     template<typename TO, typename FROM>
     struct shared_vector_converter<TO,FROM,

--- a/testApp/misc/testSharedVector.cpp
+++ b/testApp/misc/testSharedVector.cpp
@@ -556,6 +556,63 @@ static void testICE()
     }
 }
 
+static
+void testBad()
+{
+    epics::pvData::shared_vector<int> I;
+    epics::pvData::shared_vector<const int> CI;
+    epics::pvData::shared_vector<float> F;
+    epics::pvData::shared_vector<const float> CF;
+    epics::pvData::shared_vector<void> V;
+    epics::pvData::shared_vector<const void> CV;
+    (void)I;
+    (void)CI;
+    (void)F;
+    (void)CF;
+    (void)V;
+    (void)CV;
+
+    // Tests which should result in compile failure.
+    // as there is no established way to test this automatically,
+    // uncomment one at a time
+
+    // No copy from const to non-const
+    //CI = I;
+    //I = CI;
+    //epics::pvData::shared_vector<const int> CI2(I);
+    //epics::pvData::shared_vector<int> I2(CI);
+
+    // shared_vector_convert can't thaw()
+    //I = epics::pvData::shared_vector_convert<int>(CI);
+    //V = epics::pvData::shared_vector_convert<void>(CV);
+
+    // shared_vector_convert can't freeze()
+    //CI = epics::pvData::shared_vector_convert<const int>(I);
+    //CV = epics::pvData::shared_vector_convert<const void>(V);
+
+    // static_shared_vector_cast can't thaw()
+    //I = epics::pvData::static_shared_vector_cast<int>(CI);
+    //V = epics::pvData::static_shared_vector_cast<void>(CV);
+
+    // static_shared_vector_cast can't freeze()
+    //CI = epics::pvData::static_shared_vector_cast<const int>(I);
+    //CV = epics::pvData::static_shared_vector_cast<const void>(V);
+
+    // freeze() can't change type.
+    // the error here will be with the assignment
+    //I = epics::pvData::freeze(CV);
+    //I = epics::pvData::freeze(CF);
+    //CI = epics::pvData::freeze(V);
+    //CI = epics::pvData::freeze(F);
+
+    // that() can't change type.
+    // the error here will be with the assignment
+    //CI = epics::pvData::thaw(V);
+    //CI = epics::pvData::thaw(F);
+    //I = epics::pvData::thaw(CV);
+    //I = epics::pvData::that(CF);
+}
+
 MAIN(testSharedVector)
 {
     testPlan(167);
@@ -577,5 +634,6 @@ MAIN(testSharedVector)
     testVectorConvert();
     testWeak();
     testICE();
+    testBad();
     return testDone();
 }

--- a/testApp/misc/testSharedVector.cpp
+++ b/testApp/misc/testSharedVector.cpp
@@ -360,17 +360,36 @@ static void testVoid()
 
     epics::pvData::shared_vector<int32> typed(4);
 
-    epics::pvData::shared_vector<void> untyped2(epics::pvData::static_shared_vector_cast<void>(typed));
+    epics::pvData::shared_vector<void> untyped(epics::pvData::static_shared_vector_cast<void>(typed));
 
-    testOk1(typed.dataPtr().get()==untyped2.dataPtr().get());
-    testOk1(typed.size()*sizeof(int)==untyped2.size());
+    testOk1(typed.dataPtr().get()==untyped.dataPtr().get());
+    testOk1(typed.size()*sizeof(int)==untyped.size());
 
-    untyped2.slice(sizeof(int), 2*sizeof(int));
+    untyped.slice(sizeof(int), 2*sizeof(int));
 
-    typed = epics::pvData::static_shared_vector_cast<int32>(untyped2);
+    typed = epics::pvData::static_shared_vector_cast<int32>(untyped);
 
     testOk1(typed.dataOffset()==1);
     testOk1(typed.size()==2);
+    untyped.clear();
+
+    testDiag("Test vector cast to/from const void");
+
+    epics::pvData::shared_vector<const int32> ctyped(4);
+
+    epics::pvData::shared_vector<const void> cuntyped(epics::pvData::static_shared_vector_cast<const void>(ctyped));
+    // case const void to const void
+    epics::pvData::shared_vector<const void> cuntyped2(epics::pvData::static_shared_vector_cast<const void>(cuntyped));
+
+    testOk1(ctyped.dataPtr().get()==cuntyped2.dataPtr().get());
+    testOk1(ctyped.size()*sizeof(int)==cuntyped2.size());
+
+    cuntyped2.slice(sizeof(int), 2*sizeof(int));
+
+    ctyped = epics::pvData::static_shared_vector_cast<const int32>(cuntyped2);
+
+    testOk1(ctyped.dataOffset()==1);
+    testOk1(ctyped.size()==2);
 }
 
 struct dummyStruct {};
@@ -539,7 +558,7 @@ static void testICE()
 
 MAIN(testSharedVector)
 {
-    testPlan(163);
+    testPlan(167);
     testDiag("Tests for shared_vector");
 
     testDiag("sizeof(shared_vector<int32>)=%lu",

--- a/testApp/misc/testSharedVector.cpp
+++ b/testApp/misc/testSharedVector.cpp
@@ -372,7 +372,10 @@ static void testVoid()
     testOk1(typed.dataOffset()==1);
     testOk1(typed.size()==2);
     untyped.clear();
+}
 
+static void testConstVoid()
+{
     testDiag("Test vector cast to/from const void");
 
     epics::pvData::shared_vector<const int32> ctyped(4);
@@ -390,6 +393,11 @@ static void testVoid()
 
     testOk1(ctyped.dataOffset()==1);
     testOk1(ctyped.size()==2);
+
+    epics::pvData::shared_vector<void> untyped;
+    // not possible to thaw() void as shared_vector<void> has no make_unique()
+    //untyped = thaw(cuntyped);
+    cuntyped = freeze(untyped);
 }
 
 struct dummyStruct {};
@@ -630,6 +638,7 @@ MAIN(testSharedVector)
     testSlice();
     testPush();
     testVoid();
+    testConstVoid();
     testNonPOD();
     testVectorConvert();
     testWeak();

--- a/testApp/misc/testSharedVector.cpp
+++ b/testApp/misc/testSharedVector.cpp
@@ -358,46 +358,46 @@ static void testVoid()
 {
     testDiag("Test vector cast to/from void");
 
-    epics::pvData::shared_vector<int32> typed(4);
+    epics::pvData::shared_vector<int32> IV(4);
 
-    epics::pvData::shared_vector<void> untyped(epics::pvData::static_shared_vector_cast<void>(typed));
+    epics::pvData::shared_vector<void> VV(epics::pvData::static_shared_vector_cast<void>(IV));
 
-    testOk1(typed.dataPtr().get()==untyped.dataPtr().get());
-    testOk1(typed.size()*sizeof(int)==untyped.size());
+    testOk1(IV.dataPtr().get()==VV.dataPtr().get());
+    testOk1(IV.size()*sizeof(int)==VV.size());
 
-    untyped.slice(sizeof(int), 2*sizeof(int));
+    VV.slice(sizeof(int), 2*sizeof(int));
 
-    typed = epics::pvData::static_shared_vector_cast<int32>(untyped);
+    IV = epics::pvData::static_shared_vector_cast<int32>(VV);
 
-    testOk1(typed.dataOffset()==1);
-    testOk1(typed.size()==2);
-    untyped.clear();
+    testOk1(IV.dataOffset()==1);
+    testOk1(IV.size()==2);
+    VV.clear();
 }
 
 static void testConstVoid()
 {
     testDiag("Test vector cast to/from const void");
 
-    epics::pvData::shared_vector<const int32> ctyped(4);
+    epics::pvData::shared_vector<const int32> CIV(4);
 
-    epics::pvData::shared_vector<const void> cuntyped(epics::pvData::static_shared_vector_cast<const void>(ctyped));
+    epics::pvData::shared_vector<const void> CVV(epics::pvData::static_shared_vector_cast<const void>(CIV));
     // case const void to const void
-    epics::pvData::shared_vector<const void> cuntyped2(epics::pvData::static_shared_vector_cast<const void>(cuntyped));
+    epics::pvData::shared_vector<const void> CVV2(epics::pvData::static_shared_vector_cast<const void>(CVV));
 
-    testOk1(ctyped.dataPtr().get()==cuntyped2.dataPtr().get());
-    testOk1(ctyped.size()*sizeof(int)==cuntyped2.size());
+    testOk1(CIV.dataPtr().get()==CVV2.dataPtr().get());
+    testOk1(CIV.size()*sizeof(int)==CVV2.size());
 
-    cuntyped2.slice(sizeof(int), 2*sizeof(int));
+    CVV2.slice(sizeof(int), 2*sizeof(int));
 
-    ctyped = epics::pvData::static_shared_vector_cast<const int32>(cuntyped2);
+    CIV = epics::pvData::static_shared_vector_cast<const int32>(CVV2);
 
-    testOk1(ctyped.dataOffset()==1);
-    testOk1(ctyped.size()==2);
+    testOk1(CIV.dataOffset()==1);
+    testOk1(CIV.size()==2);
 
-    epics::pvData::shared_vector<void> untyped;
+    epics::pvData::shared_vector<void> VV;
     // not possible to thaw() void as shared_vector<void> has no make_unique()
-    //untyped = thaw(cuntyped);
-    cuntyped = freeze(untyped);
+    //VV = thaw(CVV);
+    CVV = freeze(VV);
 }
 
 struct dummyStruct {};

--- a/testApp/pv/testPVScalarArray.cpp
+++ b/testApp/pv/testPVScalarArray.cpp
@@ -177,11 +177,32 @@ static void testShare()
     testOk1(!cdata.unique());
 }
 
+static void testVoid()
+{
+    testDiag("Check PVScalarArray put/get from void");
+
+    PVIntArrayPtr iarr = static_pointer_cast<PVIntArray>(getPVDataCreate()->createPVScalarArray(pvInt));
+
+    PVIntArray::const_svector idata(4, 1);
+    iarr->PVScalarArray::putFrom(idata);
+    idata.clear();
+
+    shared_vector<const void> cvbuf;
+    iarr->PVScalarArray::getAs(cvbuf);
+
+    idata = static_shared_vector_cast<const PVIntArray::value_type>(cvbuf);
+    testOk1(idata.size()==4);
+
+    iarr->PVScalarArray::putFrom(cvbuf);
+
+    testOk1(iarr->getLength()==4);
+}
+
 } // end namespace
 
 MAIN(testPVScalarArray)
 {
-    testPlan(156);
+    testPlan(158);
     testFactory();
     testBasic<PVByteArray>();
     testBasic<PVUByteArray>();
@@ -189,5 +210,6 @@ MAIN(testPVScalarArray)
     testBasic<PVDoubleArray>();
     testBasic<PVStringArray>();
     testShare();
+    testVoid();
     return testDone();
 }


### PR DESCRIPTION
Fix some issues w/ shared_vector<> resulting in compile errors.  Added test cases and documentation edits

1. Allow static_shared_vector_cast<>() no-op casts (eg. void -> void).  Was a compile error
1. freeze(shared_vector<void>&) failed to compile due to missing friend and typedef
1. freeze(shared_vector<void>&) would have lost the original type due to a missing initializer.  Masked by previous compile error.
