### PR TITLE
Default implementation for Requester::message()

### DIFF
--- a/src/misc/pv/requester.h
+++ b/src/misc/pv/requester.h
@@ -65,7 +65,7 @@ public:
      };
      @endcode
      */
-    virtual void message(std::string const & message,MessageType messageType) = 0;
+    virtual void message(std::string const & message,MessageType messageType);
 };
 
 }}

--- a/src/misc/requester.cpp
+++ b/src/misc/requester.cpp
@@ -9,6 +9,7 @@
  */
 #include <string>
 #include <cstdio>
+#include <iostream>
 
 #define epicsExportSharedSymbols
 #include <pv/lock.h>
@@ -34,6 +35,9 @@ string getMessageTypeName(MessageType messageType)
     return messageTypeName[messageType];
 }
 
-
+void Requester::message(std::string const & message,MessageType messageType)
+{
+    std::cerr << "[" << getRequesterName() << "] message(" << message << ", " << getMessageTypeName(messageType) << ")\n";
+}
 
 }}


### PR DESCRIPTION
Provide a default implementation of Requester::message() which does what most sub-classes do anyway, which is print to std::cerr.  Lets prepare to remove some boilerplate!