### PR TITLE
Make release 5.0.4

### DIFF
--- a/documentation/RELEASE_NOTES.html
+++ b/documentation/RELEASE_NOTES.html
@@ -1,3 +1,30 @@
+<h1>Release 5.0.4</h1>
+
+<p>The changes since release 5.0.3 are:</p>
+
+<ul>
+<li>Fixed bitset serialization (issue #24)</li>
+<li>Fixed truncation in BitSet::or_and (issue #27)</li>
+</ul>
+
+<h2>Fixed bitset serialization (issue #24)</h2>
+
+<p>C++ bitset serialization was not consistent with the C++ deserialization and
+Java code in some instances (depending on the endianness of the serializer and deserializer) when the number of bits was 56-63 modulo 64. C++ serialization
+has been fixed.</p>
+
+<p>Fix exposed issue in deserialization on 32-bit platforms which
+has also been corrected. </p>
+
+<h2>Fixed truncation in BitSet::or_and (issue #27)</h2>
+
+<p>If n, n1 and n2 words are used to store the values of the bitsets bitset,
+bitset1 and bitset2 respectively then max(n, min(n1,n2)) words are needed
+to store bitset.or_(bitset1, bitset2).</p>
+
+<p>Previously min(n1,n2) words were used and the result would be truncated in
+some instances. This has been fixed.</p>
+
 <h1>Release 5.0.3</h1>
 
 <p>The only change since release 5.0.2 is:</p>

--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -1,3 +1,32 @@
+Release 5.0.4
+=============
+
+The changes since release 5.0.3 are:
+
+* Fixed bitset serialization (issue #24)
+* Fixed truncation in BitSet::or_and (issue #27)
+
+Fixed bitset serialization (issue #24)
+--------------------------------------
+
+C++ bitset serialization was not consistent with the C++ deserialization and
+Java code in some instances (depending on the endianness of the serializer and deserializer) when the number of bits was 56-63 modulo 64. C++ serialization
+has been fixed.
+
+Fix exposed issue in deserialization on 32-bit platforms which
+has also been corrected. 
+
+Fixed truncation in BitSet::or_and (issue #27)
+----------------------------------------------
+
+If n, n1 and n2 words are used to store the values of the bitsets bitset,
+bitset1 and bitset2 respectively then max(n, min(n1,n2)) words are needed
+to store bitset.or_(bitset1, bitset2).
+
+Previously min(n1,n2) words were used and the result would be truncated in
+some instances. This has been fixed.
+
+
 Release 5.0.3
 =============
 

--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -10,7 +10,8 @@ Fixed bitset serialization (issue #24)
 --------------------------------------
 
 C++ bitset serialization was not consistent with the C++ deserialization and
-Java code in some instances (depending on the endianness of the serializer and deserializer) when the number of bits was 56-63 modulo 64. C++ serialization
+Java code in some instances (depending on the endianness of the serializer and
+deserializer) when the number of bits was 56-63 modulo 64. C++ serialization
 has been fixed.
 
 Fix exposed issue in deserialization on 32-bit platforms which

--- a/src/misc/bitSet.cpp
+++ b/src/misc/bitSet.cpp
@@ -322,12 +322,14 @@ namespace epics { namespace pvData {
     
         SerializeHelper::writeSize(len, buffer, flusher);
         flusher->ensureBuffer(len);
-    
-        for (uint32 i = 0; i < n - 1; i++)
+   
+        n = len / 8; 
+        for (uint32 i = 0; i < n; i++)
             buffer->putLong(words[i]);
-    
-        for (uint64 x = words[n - 1]; x != 0; x >>= 8)
-            buffer->putByte((int8) (x & 0xff));
+   
+        if (n < wordsInUse) 
+            for (uint64 x = words[wordsInUse - 1]; x != 0; x >>= 8)
+                buffer->putByte((int8) (x & 0xff));
     }
     
     void BitSet::deserialize(ByteBuffer* buffer, DeserializableControl* control) {

--- a/src/misc/bitSet.cpp
+++ b/src/misc/bitSet.cpp
@@ -358,7 +358,7 @@ namespace epics { namespace pvData {
             words[j] = 0;
     
         for (uint32 remaining = (bytes - longs * 8), j = 0; j < remaining; j++)
-            words[i] |= (buffer->getByte() & 0xffL) << (8 * j);
+            words[i] |= (buffer->getByte() & 0xffLL) << (8 * j);
     
     }
     

--- a/src/misc/bitSet.cpp
+++ b/src/misc/bitSet.cpp
@@ -279,7 +279,8 @@ namespace epics { namespace pvData {
         uint32 inUse = (set1.wordsInUse < set2.wordsInUse) ? set1.wordsInUse : set2.wordsInUse;
 
         ensureCapacity(inUse);
-        wordsInUse = inUse;
+        if(inUse>wordsInUse)
+            wordsInUse = inUse;
 
         // Perform logical AND on words in common
         for (uint32 i = 0; i < inUse; i++)

--- a/testApp/misc/testBitSet.cpp
+++ b/testApp/misc/testBitSet.cpp
@@ -146,12 +146,19 @@ static void testOperators()
     b1.or_and(b2, b3);
     str = toString(b1);
     testOk1(str == "{2, 128}");
+
+    b1.clear(); b1.set(1);
+    b2.clear();
+    b3.clear(); b3.set(1);
+    std::cout<<"# "<<toString(b3)<<" |= "<<toString(b1)<<" & "<<toString(b2)<<"\n";
+    b3.or_and(b1, b2);
+    testOk(toString(b3) == "{1}", "%s == {1}", toString(b3).c_str());
 }
 
 
 MAIN(testBitSet)
 {
-    testPlan(29);
+    testPlan(30);
     testGetSetClearFlip();
     testOperators();
     return testDone();


### PR DESCRIPTION
Commits for a 5.0.4 release which patches issues found since 5.0.3.

Adds the following fixes:

* Fixed bitset serialization (issue #24)
* Fixed truncation in BitSet::or_and (issue #27)

Contains cherry picks of commits  65ff7ab1c3d8a532472b39af40acaf3480008a8b, 336a8b3bc2fb7c3123756a8e93082dbe85ecfaee and d4292d81f2391a5bb5e5747f0f6ceacec028c1e2.