### PR TITLE
Support for additional Windows targets

### DIFF
--- a/src/factory/FieldCreateFactory.cpp
+++ b/src/factory/FieldCreateFactory.cpp
@@ -8,7 +8,7 @@
  *  @author mrk
  */
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 

--- a/src/factory/PVDataCreateFactory.cpp
+++ b/src/factory/PVDataCreateFactory.cpp
@@ -8,7 +8,7 @@
  *  @author mrk
  */
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 

--- a/src/misc/epicsException.cpp
+++ b/src/misc/epicsException.cpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <cstdio>
 #include <cstring>
+#include <cstdlib>
 #include <string>
 
 #define epicsExportSharedSymbols
@@ -50,7 +51,7 @@ ExceptionMixin::show() const
             out<<symbols[i]<<"\n";
         }
 
-        free(symbols);
+        std::free(symbols);
     }
 
 #endif

--- a/src/misc/parseToPOD.cpp
+++ b/src/misc/parseToPOD.cpp
@@ -251,7 +251,7 @@ epicsParseFloat(const char *str, float *to, char **units)
 
 // MS Visual Studio 2013 defines strtoll, etc.
 #if defined(_WIN32) && !defined(_MINGW)
-#    define NEED_OLL_FUNCS (_MSC_VER < 1800)
+#    define NEED_OLL_FUNCS (EPICS_VERSION_INT < VERSION_INT(3,15,0,1))
 #elif defined(vxWorks)
 #    define NEED_OLL_FUNCS !defined(_WRS_VXWORKS_MAJOR)
 #else

--- a/src/misc/parseToPOD.cpp
+++ b/src/misc/parseToPOD.cpp
@@ -308,7 +308,7 @@ noconvert:
     return 0;
 }
 
-#if defined(__vxworks)
+#if defined(vxWorks)
 /* vxworks version of std::istringstream >>uint64_t is buggy, we use out own implementation */
 static
 unsigned long long strtoull(const char *nptr, char **endptr, int base)
@@ -551,7 +551,7 @@ void parseToPOD(const string& in, float *out) {
 void parseToPOD(const string& in, double *out) {
     int err = epicsParseDouble(in.c_str(), out, NULL);
     if(err)   handleParseError(err);
-#if defined(__vxworks)
+#if defined(vxWorks)
     /* vxWorks strtod returns [-]epicsINF when it should return ERANGE error
      * if [-]epicsINF is returned and first char is a digit then translate this into ERANGE error
      */

--- a/src/misc/parseToPOD.cpp
+++ b/src/misc/parseToPOD.cpp
@@ -250,17 +250,15 @@ epicsParseFloat(const char *str, float *to, char **units)
 #endif
 
 // MS Visual Studio 2013 defines strtoll, etc.
-#if defined(_WIN32)
-#  if (_MSC_VER >= 1800)
-#    define WIN_NEEDS_OLL_FUNC 0
-#  else
-#    define WIN_NEEDS_OLL_FUNC 1
-#  endif
+#if defined(_WIN32) && !defined(_MINGW)
+#    define NEED_OLL_FUNCS (_MSC_VER < 1800)
+#elif defined(vxWorks)
+#    define NEED_OLL_FUNCS !defined(_WRS_VXWORKS_MAJOR)
 #else
-#  define WIN_NEEDS_OLL_FUNC 0
+#    define NEED_OLL_FUNCS 0
 #endif
 
-#if defined(NEED_LONGLONG) && (defined(__vxworks) || WIN_NEEDS_OLL_FUNC)
+#if defined(NEED_LONGLONG) && NEED_OLL_FUNCS
 static
 long long strtoll(const char *ptr, char ** endp, int base)
 {

--- a/src/misc/pv/byteBuffer.h
+++ b/src/misc/pv/byteBuffer.h
@@ -11,7 +11,8 @@
 #define BYTEBUFFER_H
 
 #include <string>
-#include <string.h>
+#include <cstring>
+#include <cstdlib>
 
 #ifdef epicsExportSharedSymbols
 #define byteBufferepicsExportSharedSymbols
@@ -224,7 +225,7 @@ public:
      * Must be one of EPICS_BYTE_ORDER,EPICS_ENDIAN_LITTLE,EPICS_ENDIAN_BIG.
      */
     ByteBuffer(std::size_t size, int byteOrder = EPICS_BYTE_ORDER) :
-        _buffer((char*)malloc(size)), _size(size),
+        _buffer((char*)std::malloc(size)), _size(size),
         _reverseEndianess(byteOrder != EPICS_BYTE_ORDER),
         _reverseFloatEndianess(byteOrder != EPICS_FLOAT_WORD_ORDER),
         _wrapped(false)
@@ -257,7 +258,7 @@ public:
      */
     ~ByteBuffer()
     {
-        if (_buffer && !_wrapped) free(_buffer);
+        if (_buffer && !_wrapped) std::free(_buffer);
     }
     /**
      * Set the byte order.

--- a/src/misc/pv/epicsException.h
+++ b/src/misc/pv/epicsException.h
@@ -64,7 +64,8 @@
 
 #if defined(_WIN32) && !defined(_MINGW)
 #pragma warning( push )
-#pragma warning(disable: 4275) // warning C4275: non dll-interface class used as base for dll-interface class (std::logic_error)
+#pragma warning(disable: 4275) // non dll-interface class used as base for dll-interface class (std::logic_error)
+#pragma warning(disable: 4251) // class std::string needs to have dll-interface to be used by clients
 #endif
 
 namespace epics { namespace pvData {

--- a/src/misc/pv/epicsException.h
+++ b/src/misc/pv/epicsException.h
@@ -34,7 +34,8 @@
 #ifndef EPICSEXCEPTION_H_
 #define EPICSEXCEPTION_H_
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
+#define NOMINMAX
 #endif
 
 #include <stdexcept>

--- a/src/misc/pv/epicsException.h
+++ b/src/misc/pv/epicsException.h
@@ -35,8 +35,6 @@
 #define EPICSEXCEPTION_H_
 
 #ifdef _WIN32
-#pragma warning( push )
-#pragma warning(disable: 4275) // warning C4275: non dll-interface class used as base for dll-interface class (std::logic_error)
 #endif
 
 #include <stdexcept>
@@ -65,6 +63,11 @@
 #  define EXCEPT_USE_CAPTURE
 #else
 #  define EXCEPT_USE_NONE
+#endif
+
+#if defined(_WIN32) && !defined(_MINGW)
+#pragma warning( push )
+#pragma warning(disable: 4275) // warning C4275: non dll-interface class used as base for dll-interface class (std::logic_error)
 #endif
 
 namespace epics { namespace pvData {
@@ -228,7 +231,7 @@ private:
     mutable std::string base_msg;
 };
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(_MINGW)
 #pragma warning( pop )
 #endif
 

--- a/src/misc/pv/epicsException.h
+++ b/src/misc/pv/epicsException.h
@@ -53,7 +53,7 @@
 #  include <execinfo.h>
 #  include <cxxabi.h>
 #  define EXCEPT_USE_BACKTRACE
-#elif defined(_WIN32) && !defined(__MINGW__) && !defined(SKIP_DBGHELP)
+#elif defined(_WIN32) && !defined(_MINGW) && !defined(SKIP_DBGHELP)
 #  define _WINSOCKAPI_
 #  include <windows.h>
 #  include <dbghelp.h>

--- a/src/misc/pv/epicsException.h
+++ b/src/misc/pv/epicsException.h
@@ -40,11 +40,7 @@
 
 #include <stdexcept>
 #include <string>
-
 #include <cstdio>
-
-#include <stdio.h>
-#include <stdlib.h>
 
 #include <shareLib.h>
 

--- a/src/misc/pv/sharedPtr.h
+++ b/src/misc/pv/sharedPtr.h
@@ -26,7 +26,7 @@
 
 // where should we look?
 
-#if defined(__GNUC__) && __GNUC__>=4 && !defined(__vxworks)
+#if defined(__GNUC__) && __GNUC__>=4 && !defined(vxWorks)
    // GCC >=4.0.0
 #  define SHARED_FROM_TR1
 

--- a/src/misc/pv/sharedVector.h
+++ b/src/misc/pv/sharedVector.h
@@ -7,7 +7,7 @@
 #ifndef SHAREDVECTOR_H
 #define SHAREDVECTOR_H
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 

--- a/src/misc/timer.cpp
+++ b/src/misc/timer.cpp
@@ -8,7 +8,7 @@
  *  @author mrk
  */
  
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 

--- a/src/pv/pvData.h
+++ b/src/pv/pvData.h
@@ -29,11 +29,11 @@
 #include <shareLib.h>
 #include <compilerDependencies.h>
 
-#if defined(__vxworks) && !defined(_WRS_VXWORKS_MAJOR)
+#if defined(vxWorks) && !defined(_WRS_VXWORKS_MAJOR)
 typedef class std::ios std::ios_base;
 #endif
 
-#if defined(__GNUC__) && !(defined(__vxworks) && !defined(_WRS_VXWORKS_MAJOR))
+#if defined(__GNUC__) && !(defined(vxWorks) && !defined(_WRS_VXWORKS_MAJOR))
 #define USAGE_DEPRECATED __attribute__((deprecated))
 #define USAGE_ERROR(MSG) __attribute__((error(MSG)))
 #else

--- a/src/pv/pvData.h
+++ b/src/pv/pvData.h
@@ -33,11 +33,11 @@
 typedef class std::ios std::ios_base;
 #endif
 
+#define USAGE_DEPRECATED EPICS_DEPRECATED
+
 #if defined(__GNUC__) && !(defined(vxWorks) && !defined(_WRS_VXWORKS_MAJOR))
-#define USAGE_DEPRECATED __attribute__((deprecated))
 #define USAGE_ERROR(MSG) __attribute__((error(MSG)))
 #else
-#define USAGE_DEPRECATED
 #define USAGE_ERROR(MSG) { throw std::runtime_error(MSG); }
 #endif
 

--- a/src/pv/pvData.h
+++ b/src/pv/pvData.h
@@ -437,6 +437,16 @@ private:
 };
 
 /**
+ * @brief Some explicit specializations exist (defined in PVScalar.cpp)
+ */
+template<>
+    std::ostream& PVScalarValue<int8>::dumpValue(std::ostream& o) const;
+template<>
+    std::ostream& PVScalarValue<uint8>::dumpValue(std::ostream& o) const;
+template<>
+    std::ostream& PVScalarValue<boolean>::dumpValue(std::ostream& o) const;
+
+/**
  * typedefs for the various possible scalar types.
  */
 typedef PVScalarValue<boolean> PVBoolean;

--- a/src/pv/pvData.h
+++ b/src/pv/pvData.h
@@ -10,7 +10,7 @@
 #ifndef PVDATA_H
 #define PVDATA_H
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 

--- a/src/pv/pvType.h
+++ b/src/pv/pvType.h
@@ -27,7 +27,7 @@
 #include <string>
 #include <vector>
 
-#if defined(__vxworks) && \
+#if defined(vxWorks) && \
     (_WRS_VXWORKS_MAJOR+0 <= 6) && (_WRS_VXWORKS_MINOR+0 < 9)
 typedef int intptr_t;
 typedef unsigned int uintptr_t;

--- a/src/pv/pvType.h
+++ b/src/pv/pvType.h
@@ -17,6 +17,10 @@
 
 #ifdef _WIN32
 #define NOMINMAX
+#endif
+
+#if defined(_WIN32) && !defined(_MINGW)
+#pragma warning( push )
 #pragma warning(disable: 4251)
 #endif
 
@@ -126,7 +130,9 @@ typedef std::vector<std::string>::iterator StringArray_iterator;
 typedef std::vector<std::string>::const_iterator StringArray_const_iterator;
 
 }}
+
+#if defined(_WIN32) && !defined(_MINGW)
+#pragma warning( pop )
+#endif
+
 #endif  /* PVTYPE_H */
-
-
-

--- a/src/pv/pvType.h
+++ b/src/pv/pvType.h
@@ -15,7 +15,7 @@
 #ifndef PVTYPE_H
 #define PVTYPE_H
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 

--- a/testApp/misc/testBitSet.cpp
+++ b/testApp/misc/testBitSet.cpp
@@ -6,7 +6,7 @@
  */
 /* Author:  Matej Sekoranja Date: 2010.10.18 */
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 

--- a/testApp/misc/testSerialization.cpp
+++ b/testApp/misc/testSerialization.cpp
@@ -10,7 +10,7 @@
  *      Author: Miha Vitorovic
  */
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 

--- a/testApp/misc/testTypeCast.cpp
+++ b/testApp/misc/testTypeCast.cpp
@@ -5,7 +5,7 @@
  */
 /* Author:  Michael Davidsaver */
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 


### PR DESCRIPTION
These changes allow pvDataCPP to be built for the Cygwin and MinGW targets, including cross-compiling for MinGW on Linux. A few other minor cleanups are included as well.