### PR TITLE
This file needs to have the epicsExportSharedSymbols define cached in…

### DIFF
--- a/src/misc/pv/thread.h
+++ b/src/misc/pv/thread.h
@@ -17,8 +17,18 @@
 #include <functional>
 #endif
 
+#ifdef epicsExportSharedSymbols
+#   define ThreadEpicsExportSharedSymbols
+#   undef epicsExportSharedSymbols
+#endif
+
 #include <epicsThread.h>
 #include <shareLib.h>
+
+#ifdef ThreadEpicsExportSharedSymbols
+#   undef ThreadEpicsExportSharedSymbols
+#   define epicsExportSharedSymbols
+#endif
 
 #include <pv/noDefaultMethods.h>
 #include <pv/pvType.h>


### PR DESCRIPTION
… order to build correctly in a debug build.

Otherwise epicsThreadRunable is a multiply defined symbol.