### PR TITLE
Add char* overload for non-template getSubField

### DIFF
--- a/src/factory/PVStructure.cpp
+++ b/src/factory/PVStructure.cpp
@@ -104,9 +104,9 @@ const PVFieldPtrArray & PVStructure::getPVFields() const
     return pvFields;
 }
 
-PVFieldPtr  PVStructure::getSubField(string const &fieldName) const
+PVFieldPtr  PVStructure::getSubField(const char * fieldName) const
 {
-    PVField * field = getSubFieldImpl(fieldName.c_str(), false);
+    PVField * field = getSubFieldImpl(fieldName, false);
     if (field)
        return field->shared_from_this();
     else

--- a/src/pv/pvData.h
+++ b/src/pv/pvData.h
@@ -702,7 +702,12 @@ public:
      * @param fieldName The name of the field.
      * @return Pointer to the field or null if field does not exist.
      */
-    PVFieldPtr getSubField(std::string const &fieldName) const;
+    FORCE_INLINE PVFieldPtr getSubField(std::string const &fieldName) const
+    {
+        return getSubField(fieldName.c_str());
+    }
+
+    PVFieldPtr getSubField(const char *fieldName) const;
 
     /**
      * Get a subfield with the specified name.


### PR DESCRIPTION
Template getSubField has overload for c-strings but not non-template version. Add for non-template. Improves performance when argument is string literal.