### PR TITLE
Replace template getSubField with template version

### DIFF
--- a/src/copy/pvCopy.cpp
+++ b/src/copy/pvCopy.cpp
@@ -83,7 +83,7 @@ PVCopyPtr PVCopy::create(
             pvStructure = pvRequest->getSubField<PVStructure>(structureName);
             if(!pvStructure) return NULLPVCopy;
         }
-    } else if(pvStructure->getSubField("field")) {
+    } else if(pvStructure->getSubField<PVStructure>("field")) {
         pvStructure = pvRequest->getSubField<PVStructure>("field");
     }
     PVCopyPtr pvCopy = PVCopyPtr(new PVCopy(pvMaster));
@@ -444,9 +444,7 @@ CopyNodePtr PVCopy::createStructureNodes(
         string fieldName = copyPVField->getFieldName();
         
         PVStructurePtr requestPVStructure = pvFromRequest->getSubField<PVStructure>(fieldName);
-        PVStructurePtr pvSubFieldOptions;
-        PVFieldPtr pvField = requestPVStructure->getSubField("_options");
-        if(pvField) pvSubFieldOptions = static_pointer_cast<PVStructure>(pvField);
+        PVStructurePtr pvSubFieldOptions = requestPVStructure->getSubField<PVStructure>("_options");
         PVFieldPtr pvMasterField;
         PVFieldPtrArray const & pvMasterFields = pvMasterStructure->getPVFields();
         for(size_t j=0; i<pvMasterFields.size(); j++ ) {

--- a/testApp/copy/testCreateRequest.cpp
+++ b/testApp/copy/testCreateRequest.cpp
@@ -42,9 +42,9 @@ static void testCreateRequestInternal() {
     if(!pvRequest) { cout<< createRequest->getMessage() << endl;}
     if(debug) { cout << pvRequest << endl;}
     testOk1(pvRequest.get()!=NULL);
-    testOk1(pvRequest->getSubField("field").get()!=NULL);
-    testOk1(pvRequest->getSubField("putField").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("putField").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField").get()!=NULL);
     testPass("request %s",request.c_str());
 
     request = "record[a=b,x=y]field(a) putField(a),getField(a)";
@@ -59,9 +59,9 @@ static void testCreateRequestInternal() {
     pvString = pvRequest->getSubField<PVString>("record._options.x");
     sval = pvString->get();
     testOk(sval.compare("y")==0,"record.x = y");
-    testOk1(pvRequest->getSubField("field.a").get()!=NULL);
-    testOk1(pvRequest->getSubField("putField.a").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.a").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.a").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("putField.a").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.a").get()!=NULL);
     testPass("request %s",request.c_str());
 
     request = "field(a.b[x=y])";
@@ -93,7 +93,7 @@ static void testCreateRequestInternal() {
     pvString = pvRequest->getSubField<PVString>("field.a.b._options.x");
     sval = pvString->get();
     testOk(sval.compare("y")==0,"field.a.b._options.x = y");
-    testOk1(pvRequest->getSubField("field.a.b.c.d").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.a.b.c.d").get()!=NULL);
     testPass("request %s",request.c_str());
 
     request = "field(a.b[x=y]{c.d[x=y]})";
@@ -125,8 +125,8 @@ static void testCreateRequestInternal() {
     pvString = pvRequest->getSubField<PVString>("field.b.a._options.a");
     sval = pvString->get();
     testOk(sval.compare("b")==0,"field.b.a._options.a = b");
-    testOk1(pvRequest->getSubField("field.b.a.a").get()!=NULL);
-    testOk1(pvRequest->getSubField("field.b.a.b").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.b.a.a").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.b.a.b").get()!=NULL);
     testPass("request %s",request.c_str());
 
 
@@ -136,9 +136,9 @@ static void testCreateRequestInternal() {
     if(!pvRequest) { cout<< createRequest->getMessage() << endl;}
     if(debug) { cout << pvRequest << endl;}
     testOk1(pvRequest.get()!=NULL);
-    testOk1(pvRequest->getSubField("field.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("field.timeStamp").get()!=NULL);
-    testOk1(pvRequest->getSubField("field.power.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.timeStamp").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.power.value").get()!=NULL);
     testPass("request %s",request.c_str());
 
     request = "record[process=true]field(alarm,timeStamp,power.value)";
@@ -150,9 +150,9 @@ static void testCreateRequestInternal() {
     pvString = pvRequest->getSubField<PVString>("record._options.process");
     sval = pvString->get();
     testOk(sval.compare("true")==0,"record._options.process = true");
-    testOk1(pvRequest->getSubField("field.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("field.timeStamp").get()!=NULL);
-    testOk1(pvRequest->getSubField("field.power.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.timeStamp").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.power.value").get()!=NULL);
     testPass("request %s",request.c_str());
 
     request = "record[process=true]field(alarm,timeStamp[algorithm=onChange,causeMonitor=false],power{value,alarm})";
@@ -164,16 +164,16 @@ static void testCreateRequestInternal() {
     pvString = pvRequest->getSubField<PVString>("record._options.process");
     sval = pvString->get();
     testOk(sval.compare("true")==0,"record._options.process = true");
-    testOk1(pvRequest->getSubField("field.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("field.timeStamp").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.timeStamp").get()!=NULL);
     pvString = pvRequest->getSubField<PVString>("field.timeStamp._options.algorithm");
     sval = pvString->get();
     testOk(sval.compare("onChange")==0,"field.timeStamp._options.algorithm = onChange");
     pvString = pvRequest->getSubField<PVString>("field.timeStamp._options.causeMonitor");
     sval = pvString->get();
     testOk(sval.compare("false")==0,"field.timeStamp._options.causeMonitor = false");
-    testOk1(pvRequest->getSubField("field.power.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("field.power.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.power.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.power.alarm").get()!=NULL);
     testPass("request %s",request.c_str());
 
     request = "record[int=2,float=3.14159]field(alarm,timeStamp[shareData=true],power.value)";
@@ -188,11 +188,11 @@ static void testCreateRequestInternal() {
     pvString = pvRequest->getSubField<PVString>("record._options.float");
     sval = pvString->get();
     testOk(sval.compare("3.14159")==0,"record._options.float = 3.14159");
-    testOk1(pvRequest->getSubField("field.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.alarm").get()!=NULL);
     pvString = pvRequest->getSubField<PVString>("field.timeStamp._options.shareData");
     sval = pvString->get();
     testOk(sval.compare("true")==0,"field.timeStamp._options.shareData = true");
-    testOk1(pvRequest->getSubField("field.power.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.power.value").get()!=NULL);
     testPass("request %s",request.c_str());
 
     request = string("record[process=true,xxx=yyy]")
@@ -204,15 +204,15 @@ static void testCreateRequestInternal() {
     if(!pvRequest) { cout<< createRequest->getMessage() << endl;}
     if(debug) { cout << pvRequest << endl;}
     testOk1(pvRequest.get()!=NULL);
-    testOk1(pvRequest->getSubField("putField.power.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.timeStamp").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.power.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.power.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.current.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.current.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.voltage.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.voltage.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("putField.power.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.timeStamp").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.power.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.power.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.current.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.current.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.voltage.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.voltage.alarm").get()!=NULL);
     testPass("request %s",request.c_str());
 
     request = string("field(alarm,timeStamp,supply{")
@@ -224,14 +224,14 @@ static void testCreateRequestInternal() {
     if(!pvRequest) { cout<< createRequest->getMessage() << endl;}
     if(debug) { cout << pvRequest << endl;}
     testOk1(pvRequest.get()!=NULL);
-    testOk1(pvRequest->getSubField("field.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("field.timeStamp").get()!=NULL);
-    testOk1(pvRequest->getSubField("field.supply.zero.voltage.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("field.supply.zero.current.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("field.supply.zero.power.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("field.supply.one.voltage.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("field.supply.one.current.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("field.supply.one.power.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.timeStamp").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.supply.zero.voltage.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.supply.zero.current.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.supply.zero.power.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.supply.one.voltage.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.supply.one.current.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.supply.one.power.value").get()!=NULL);
     testPass("request %s",request.c_str());
 
     request = string("record[process=true,xxx=yyy]")
@@ -246,31 +246,31 @@ static void testCreateRequestInternal() {
     if(!pvRequest) { cout<< createRequest->getMessage() << endl;}
     if(debug) { cout << pvRequest << endl;}
     testOk1(pvRequest.get()!=NULL);
-    testOk1(pvRequest->getSubField("putField.power.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.timeStamp").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.power.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.power.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.current.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.current.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.voltage.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.voltage.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps0.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps0.timeStamp").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps0.power.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps0.power.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps0.current.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps0.current.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps0.voltage.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps0.voltage.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps1.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps1.timeStamp").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps1.power.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps1.power.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps1.current.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps1.current.alarm").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps1.voltage.value").get()!=NULL);
-    testOk1(pvRequest->getSubField("getField.ps1.voltage.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("putField.power.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.timeStamp").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.power.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.power.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.current.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.current.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.voltage.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.voltage.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps0.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps0.timeStamp").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps0.power.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps0.power.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps0.current.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps0.current.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps0.voltage.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps0.voltage.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps1.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps1.timeStamp").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps1.power.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps1.power.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps1.current.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps1.current.alarm").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps1.voltage.value").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("getField.ps1.voltage.alarm").get()!=NULL);
     testPass("request %s",request.c_str());
 
     request = "a{b{c{d}}}";
@@ -279,7 +279,7 @@ static void testCreateRequestInternal() {
     if(!pvRequest) { cout<< createRequest->getMessage() << endl;}
     if(debug) { cout << pvRequest << endl;}
     testOk1(pvRequest.get()!=NULL);
-    testOk1(pvRequest->getSubField("field.a.b.c.d").get()!=NULL);
+    testOk1(pvRequest->getSubField<PVStructure>("field.a.b.c.d").get()!=NULL);
     testPass("request %s",request.c_str());
 
     request = string("record[process=true,xxx=yyy]")

--- a/testApp/copy/testPVCopy.cpp
+++ b/testApp/copy/testPVCopy.cpp
@@ -41,21 +41,18 @@ static void testPVScalar(
     PVCopyPtr const & pvCopy)
 {
     PVStructurePtr pvStructureCopy;
-    PVFieldPtr pvField;
     PVScalarPtr pvValueMaster;
     PVScalarPtr pvValueCopy;
     BitSetPtr bitSet;
     size_t offset;
     ConvertPtr convert = getConvert();
 
-    pvField = pvMaster->getSubField(valueNameMaster);
-    pvValueMaster = static_pointer_cast<PVScalar>(pvField);
+    pvValueMaster = pvMaster->getSubField<PVScalar>(valueNameMaster);
     convert->fromDouble(pvValueMaster,.04);
     StructureConstPtr structure = pvCopy->getStructure();
     if(debug) { cout << "structure from copy" << endl << *structure << endl; }
     pvStructureCopy = pvCopy->createPVStructure();
-    pvField = pvStructureCopy->getSubField(valueNameCopy);
-    pvValueCopy = static_pointer_cast<PVScalar>(pvField);
+    pvValueCopy = pvStructureCopy->getSubField<PVScalar>(valueNameCopy);
     bitSet = BitSetPtr(new BitSet(pvStructureCopy->getNumberFields()));
     pvCopy->initCopy(pvStructureCopy, bitSet);
     if(debug) { cout << "after initCopy pvValueCopy " << convert->toDouble(pvValueCopy); }

--- a/testApp/property/testProperty.cpp
+++ b/testApp/property/testProperty.cpp
@@ -71,7 +71,7 @@ static void testAlarm()
     Alarm alarm;
     PVAlarm pvAlarm; 
     bool result;
-    PVFieldPtr pvField = doubleRecord->getSubField(string("alarm"));
+    PVFieldPtr pvField = doubleRecord->getSubField<PVStructure>(string("alarm"));
     if(pvField.get()==NULL) {
         printf("testAlarm ERROR did not find field alarm\n");
         return;
@@ -104,7 +104,7 @@ static void testTimeStamp()
     TimeStamp timeStamp;
     PVTimeStamp pvTimeStamp; 
     bool result;
-    PVFieldPtr pvField = doubleRecord->getSubField(string("timeStamp"));
+    PVFieldPtr pvField = doubleRecord->getSubField<PVStructure>(string("timeStamp"));
     if(pvField.get()==NULL) {
         printf("testTimeStamp ERROR did not find field timeStamp\n");
         return;
@@ -144,7 +144,7 @@ static void testControl()
     Control control;
     PVControl pvControl; 
     bool result;
-    PVFieldPtr pvField = doubleRecord->getSubField(string("control"));
+    PVFieldPtr pvField = doubleRecord->getSubField<PVStructure>(string("control"));
     if(pvField.get()==NULL) {
         printf("testControl ERROR did not find field control\n");
         return;
@@ -171,7 +171,7 @@ static void testDisplay()
     Display display;
     PVDisplay pvDisplay; 
     bool result;
-    PVFieldPtr pvField = doubleRecord->getSubField(string("display"));
+    PVFieldPtr pvField = doubleRecord->getSubField<PVStructure>(string("display"));
     if(pvField.get()==NULL) {
         printf("testDisplay ERROR did not find field display\n");
         return;
@@ -203,7 +203,7 @@ static void testEnumerated()
     if(debug) printf("testEnumerated\n");
     PVEnumerated pvEnumerated; 
     bool result;
-    PVFieldPtr pvField = enumeratedRecord->getSubField(string("value"));
+    PVFieldPtr pvField = enumeratedRecord->getSubField<PVStructure>(string("value"));
     if(pvField.get()==NULL) {
         printf("testEnumerated ERROR did not find field enumerated\n");
         return;

--- a/testApp/pv/testBitSetUtil.cpp
+++ b/testApp/pv/testBitSetUtil.cpp
@@ -84,13 +84,13 @@ static void test()
         std::cout << oss.str();
     }     
     bitSet->clear();
-    PVFieldPtr pvField = pvs->getSubField("timeStamp");
+    PVFieldPtr pvField = pvs->getSubField<PVStructure>("timeStamp");
     int32 offsetTimeStamp = (int32)pvField->getFieldOffset();
-    pvField = pvs->getSubField("timeStamp.secondsPastEpoch");
+    pvField = pvs->getSubField<PVLong>("timeStamp.secondsPastEpoch");
     int32 offsetSeconds = (int32)pvField->getFieldOffset();
-    pvField = pvs->getSubField("timeStamp.nanoseconds");
+    pvField = pvs->getSubField<PVInt>("timeStamp.nanoseconds");
     int32 offsetNano = (int32)pvField->getFieldOffset();
-    pvField = pvs->getSubField("timeStamp.userTag");
+    pvField = pvs->getSubField<PVInt>("timeStamp.userTag");
     int32 offsetUserTag = (int32)pvField->getFieldOffset();
     bitSet->set(offsetSeconds);
     BitSetUtil::compress(bitSet,pvs);
@@ -114,17 +114,17 @@ static void test()
     }     
     bitSet->clear();
 
-    pvField = pvs->getSubField("current");
+    pvField = pvs->getSubField<PVStructure>("current");
     int32 offsetCurrent = (int32)pvField->getFieldOffset();
-    pvField = pvs->getSubField("current.value");
+    pvField = pvs->getSubField<PVDouble>("current.value");
     int32 offsetValue = (int32)pvField->getFieldOffset();
-    pvField = pvs->getSubField("current.alarm");
+    pvField = pvs->getSubField<PVStructure>("current.alarm");
     int32 offsetAlarm = (int32)pvField->getFieldOffset();
-    pvField = pvs->getSubField("current.alarm.severity");
+    pvField = pvs->getSubField<PVInt>("current.alarm.severity");
     int32 offsetSeverity = (int32)pvField->getFieldOffset();
-    pvField = pvs->getSubField("current.alarm.status");
+    pvField = pvs->getSubField<PVInt>("current.alarm.status");
     int32 offsetStatus = (int32)pvField->getFieldOffset();
-    pvField = pvs->getSubField("current.alarm.message");
+    pvField = pvs->getSubField<PVString>("current.alarm.message");
     int32 offsetMessage = (int32)pvField->getFieldOffset();
     bitSet->set(offsetValue);
     bitSet->set(offsetSeverity);

--- a/testApp/pv/testPVData.cpp
+++ b/testApp/pv/testPVData.cpp
@@ -260,18 +260,12 @@ static void testPVScalarWithProperties(
         limit->put(9.0);
     }
     if(hasValueAlarm) {
-        PVFieldPtr  pvField = pvStructure->getSubField(
-            string("valueAlarm.active"));
-        PVBooleanPtr pvBoolean = static_pointer_cast<PVBoolean>(pvField);
+        PVBooleanPtr pvBoolean = pvStructure->getSubField<PVBoolean>("valueAlarm.active");
         pvBoolean->put(true);
-        pvField = pvStructure->getSubField(
-            string("valueAlarm.lowAlarmLimit"));
-        PVScalarPtr pvtemp = static_pointer_cast<PVScalar>(pvField);
+        PVScalarPtr pvtemp = pvStructure->getSubField<PVScalar>("valueAlarm.lowAlarmLimit");
         testOk1(pvtemp.get()!=0);
         convert->fromDouble(pvtemp,1.0);
-        pvField = pvStructure->getSubField(
-            string("valueAlarm.highAlarmLimit"));
-        pvtemp = static_pointer_cast<PVScalar>(pvField);
+        pvtemp = pvStructure->getSubField<PVScalar>("valueAlarm.highAlarmLimit");
         testOk1(pvtemp.get()!=0);
         convert->fromDouble(pvtemp,9.0);
         severity = pvStructure->getSubField<PVInt>(
@@ -288,9 +282,7 @@ static void testPVScalarWithProperties(
         active->put(true);
     }
     if(hasBooleanAlarm) {
-        PVFieldPtr  pvField = pvStructure->getSubField(
-            string("valueAlarm.active"));
-        PVBooleanPtr pvBoolean = static_pointer_cast<PVBoolean>(pvField);
+        PVBooleanPtr pvBoolean = pvStructure->getSubField<PVBoolean>("valueAlarm.active");
         pvBoolean->put(true);
         severity = pvStructure->getSubField<PVInt>(
             string("valueAlarm.falseSeverity"));
@@ -364,7 +356,7 @@ static void testScalarArrayCommon(string /*fieldName*/,ScalarType stype)
     }
     if(debug)
         std::cout << *pvStructure << std::endl;
-    PVFieldPtr pvField = pvStructure->getSubField("alarm.status");
+    PVFieldPtr pvField = pvStructure->getSubField<PVInt>("alarm.status");
     testOk1(pvField.get()!=0);
 }
 
@@ -425,7 +417,7 @@ pvString->put("true");
 cout << *pvTop << endl;
 
 string subName("record._options.process");
-PVFieldPtr pvField = pvTop->getSubField(subName);
+PVFieldPtr pvField = pvTop->getSubField<PVString>(subName);
 string fieldName = pvField->getFieldName();
 string fullName = pvField->getFullName();
 cout << "fieldName " << fieldName << " fullName " << fullName << endl;


### PR DESCRIPTION
Replace non-template getSubField with template version when PVField is of a known, derived type.

As per #34,but only do for derived classes. Avoid getSubField&lt;PVField&gt; as the dynamic_pointer_cast is not (as you might think) a null op. Especially avoid in the offset version as this can lead to several unnecessary pointer casts (see discussion in #34). In #34 there are sometimes more appropriate types for the template argument so use these.