### PR TITLE
Resolve github #37 without cacheing epicsExportSharedSymbols

### DIFF
--- a/src/misc/executor.cpp
+++ b/src/misc/executor.cpp
@@ -13,6 +13,10 @@
 #include <string>
 #include <cstdio>
 
+#include <epicsEvent.h>
+#include <epicsMutex.h>
+#include <epicsThread.h>
+
 #define epicsExportSharedSymbols
 #include <pv/executor.h>
 


### PR DESCRIPTION
My preferred solution to Peter Heesterman's issue #37 