### PR TITLE
Disable warning 4344 for Windows targets

### DIFF
--- a/src/pv/pvData.h
+++ b/src/pv/pvData.h
@@ -32,6 +32,12 @@
 typedef class std::ios std::ios_base;
 #endif
 
+#if defined(_WIN32) && !defined(_MINGW)
+#pragma warning(disable: 4344) // A call to a function using explicit template
+// arguments calls a different function than it would if explicit arguments had not been specified
+// Removes warnings for template getSubField.
+#endif
+
 #define USAGE_DEPRECATED EPICS_DEPRECATED
 
 #if defined(__GNUC__) && !(defined(vxWorks) && !defined(_WRS_VXWORKS_MAJOR))


### PR DESCRIPTION
On Windows every call of the template getSubField (or the throwing getSubFieldT) leads to a level 1 build warning (4344), e.g.

"warning C4344: behavior change: use of explicit template arguments results in call to 'std::tr1::shared_ptr<_Ty> epics::pvData::PVStructure::getSubField
T<epics::pvData::PVInt>(const char *) const'
        with
        [
            _Ty=epics::pvData::PVInt
        ]
        but the regular function 'epics::pvData::PVFieldPtr epics::pvData::PVStructure::getSubFieldT
(const std::string &) const' is a better match
        if you expect 'epics::pvData::PVFieldPtr epics::pvData::PVStructure::getSubFieldT(const std:
:string &) const' to be called then you need to make it an explicit specialization"

This seems to me a very stupid warning: You explicitly tell the compiler you want to call the template function and the compiler tells that if you hadn't explicitly told it to call the template function it would have called the non-template. No other compiler warns about this.

I'd like disable this warning as it generates a very noisy message in every bit of code that calls a template getSubField[T] and the thing being warned about is not an issue.