### PR TITLE
add new public member updateMasterSetBitSet

### DIFF
--- a/src/copy/pv/pvCopy.h
+++ b/src/copy/pv/pvCopy.h
@@ -157,6 +157,15 @@ public:
         PVStructurePtr const  &copyPVStructure,
         BitSetPtr const  &bitSet);
     /**
+     * Set each field in pvMaster to the value of the corresponding field in copyPVStructure.
+     * For each field that changes value set the corresponding bit in bitSet.
+     * @param copyPVStructure A copy top-level structure.
+     * @param bitSet A bitSet for copyPVStructure.
+     */
+    void updateMasterSetBitSet(
+        PVStructurePtr const  &copyPVStructure,
+        BitSetPtr const  &bitSet);
+    /**
      * Get the options for the field at the specified offset.
      * @param fieldOffset the offset in copy.
      * @returns A NULL is returned if no options were specified for the field.
@@ -218,6 +227,14 @@ private:
         BitSetPtr const &bitSet,
         bool toCopy,
         bool doAll);
+    void updateMasterSetBitSet(
+        PVStructurePtr const &pvCopy,
+        CopyStructureNodePtr const &structureNode,
+        BitSetPtr const &bitSet);
+    void updateMasterSubFieldSetBitSet(
+        PVFieldPtr const &pvCopy,
+        PVFieldPtr const &pvMaster,
+        BitSetPtr const &bitSet);
     CopyMasterNodePtr getCopyOffset(
         CopyStructureNodePtr const &structureNode,
         PVFieldPtr const &masterPVField);

--- a/src/copy/pv/pvCopy.h
+++ b/src/copy/pv/pvCopy.h
@@ -14,6 +14,7 @@
 #include <memory>
 
 #include <shareLib.h>
+#include <compilerDependencies.h>
 
 #include <pv/pvData.h>
 #include <pv/bitSet.h>
@@ -75,7 +76,7 @@ public:
         PVStructurePtr const &pvRequest,
         std::string const & structureName);
     virtual ~PVCopy(){}
-    void destroy();
+    void destroy() EPICS_DEPRECATED;
     /**
      * Get the top-level structure of master
      * @returns The master top-level structure.
@@ -170,7 +171,7 @@ public:
      * @param fieldOffset the offset in copy.
      * @returns A NULL is returned if no options were specified for the field.
      * If options were specified,PVStructurePtr is a structures
-     *  with a set of PVString subfields that specify name,value pairs.s
+     *  with a set of PVString subfields that specify name,value pairs.
      *  name is the subField name and value is the subField value.
      */
     PVStructurePtr getOptions(std::size_t fieldOffset);

--- a/src/copy/pvCopy.cpp
+++ b/src/copy/pvCopy.cpp
@@ -270,6 +270,7 @@ void PVCopy::updateCopyFromBitSet(
     }
 }
 
+
 void PVCopy::updateMaster(
     PVStructurePtr const  &copyPVStructure,
     BitSetPtr const  &bitSet)
@@ -284,6 +285,30 @@ void PVCopy::updateMaster(
         CopyMasterNodePtr masterNode =
             static_pointer_cast<CopyMasterNode>(headNode);
         updateSubFieldFromBitSet( copyPVStructure,masterNode->masterPVField,bitSet,false,doAll);
+    }
+}
+
+void PVCopy::updateMasterSetBitSet(
+    PVStructurePtr const  &copyPVStructure,
+    BitSetPtr const  &bitSet)
+{
+    if(headNode->isStructure) {
+        CopyStructureNodePtr node = static_pointer_cast<CopyStructureNode>(headNode);
+        updateMasterSetBitSet(copyPVStructure,node,bitSet);
+    } else {
+        CopyMasterNodePtr masterNode = static_pointer_cast<CopyMasterNode>(headNode);
+        PVFieldPtr pvMasterField= masterNode->masterPVField;
+        PVFieldPtr copyPVField = copyPVStructure;
+        PVFieldPtr pvField = pvMasterField;
+        if(pvField->getField()->getType()==epics::pvData::structure) {
+            updateMasterSubFieldSetBitSet(copyPVField,pvMasterField,bitSet);
+            return;
+        }
+        bool isEqual = (*copyPVField == *pvField);
+        if(!isEqual) {
+            pvField->copyUnchecked(*copyPVField);
+            bitSet->set(pvField->getFieldOffset());
+        }
     }
 }
 
@@ -600,6 +625,61 @@ void PVCopy::updateSubFieldFromBitSet(
         }
     }
 }
+
+void PVCopy::updateMasterSetBitSet(
+        PVStructurePtr const &pvCopy,
+        CopyStructureNodePtr const &structureNode,
+        BitSetPtr const &bitSet)
+{
+    for(size_t i=0; i<structureNode->nodes->size(); i++) {
+        CopyNodePtr node = (*structureNode->nodes)[i];
+        PVFieldPtr pvField = pvCopy->getSubField(node->structureOffset);
+        if(node->isStructure) {
+            PVStructurePtr xxx = static_pointer_cast<PVStructure>(pvField);
+            CopyStructureNodePtr yyy =
+                static_pointer_cast<CopyStructureNode>(node);
+            updateMasterSetBitSet(xxx,yyy,bitSet); 
+        } else {
+            CopyMasterNodePtr masterNode =
+                static_pointer_cast<CopyMasterNode>(node);
+            updateMasterSubFieldSetBitSet(pvField,masterNode->masterPVField,bitSet);
+        }
+    }
+}
+
+void PVCopy::updateMasterSubFieldSetBitSet(
+        PVFieldPtr const &pvCopy,
+        PVFieldPtr const &pvMaster,
+        BitSetPtr const &bitSet)
+{
+    FieldConstPtr field = pvCopy->getField();
+    Type type = field->getType();
+    if(type!=epics::pvData::structure) {
+        bool isEqual = (*pvCopy == *pvMaster);
+    	if(isEqual) {
+    	    if(type==structureArray) {
+    	        // always act as though a change occurred.
+    	        // Note that array elements are shared.
+                bitSet->set(pvCopy->getFieldOffset());
+    	    }
+    	}
+        if(isEqual) return;
+        pvMaster->copyUnchecked(*pvCopy);
+        bitSet->set(pvCopy->getFieldOffset());
+        return;
+    }
+    PVStructurePtr pvCopyStructure = static_pointer_cast<PVStructure>(pvCopy);
+    PVFieldPtrArray const & pvCopyFields = pvCopyStructure->getPVFields();
+    PVStructurePtr pvMasterStructure =
+        static_pointer_cast<PVStructure>(pvMaster);
+    PVFieldPtrArray const & pvMasterFields =
+        pvMasterStructure->getPVFields();
+    size_t length = pvCopyFields.size();
+    for(size_t i=0; i<length; i++) {
+        updateMasterSubFieldSetBitSet(pvCopyFields[i],pvMasterFields[i],bitSet);
+    }
+}
+
 
 CopyMasterNodePtr PVCopy::getCopyOffset(
         CopyStructureNodePtr const &structureNode,

--- a/src/copy/pvCopy.cpp
+++ b/src/copy/pvCopy.cpp
@@ -92,7 +92,6 @@ PVCopy::PVCopy(
 
 void PVCopy::destroy()
 {
-    headNode.reset();
 }
 
 PVStructurePtr PVCopy::getPVMaster()


### PR DESCRIPTION
With this new method PVCopy can be used by the ca provider in pvAccess to better  support  change and overrun bit sets..