### PR TITLE
Field instance de-duplication

### DIFF
--- a/src/factory/Compare.cpp
+++ b/src/factory/Compare.cpp
@@ -23,7 +23,7 @@ namespace epics { namespace pvData {
  * 1) same instance
  * 2) same type (field and scalar/element), same name, same subfields (if any)
  */
-bool operator==(const Field& a, const Field& b)
+bool compare(const Field& a, const Field& b)
 {
     if(&a==&b)
         return true;
@@ -33,53 +33,53 @@ bool operator==(const Field& a, const Field& b)
     case scalar: {
         const Scalar &A=static_cast<const Scalar&>(a);
         const Scalar &B=static_cast<const Scalar&>(b);
-        return A==B;
+        return compare(A, B);
     }
     case scalarArray: {
             const ScalarArray &A=static_cast<const ScalarArray&>(a);
             const ScalarArray &B=static_cast<const ScalarArray&>(b);
-            return A==B;
+            return compare(A, B);
         }
     case structure: {
             const Structure &A=static_cast<const Structure&>(a);
             const Structure &B=static_cast<const Structure&>(b);
-            return A==B;
+            return compare(A, B);
         }
     case structureArray: {
             const StructureArray &A=static_cast<const StructureArray&>(a);
             const StructureArray &B=static_cast<const StructureArray&>(b);
-            return A==B;
+            return compare(A, B);
         }
     case union_: {
             const Union &A=static_cast<const Union&>(a);
             const Union &B=static_cast<const Union&>(b);
-            return A==B;
+            return compare(A, B);
         }
     case unionArray: {
             const UnionArray &A=static_cast<const UnionArray&>(a);
             const UnionArray &B=static_cast<const UnionArray&>(b);
-            return A==B;
+            return compare(A, B);
         }
     default:
         throw std::logic_error("Invalid Field type in comparison");
     }
 }
 
-bool operator==(const Scalar& a, const Scalar& b)
+bool compare(const Scalar& a, const Scalar& b)
 {
     if(&a==&b)
         return true;
     return a.getScalarType()==b.getScalarType();
 }
 
-bool operator==(const ScalarArray& a, const ScalarArray& b)
+bool compare(const ScalarArray& a, const ScalarArray& b)
 {
     if(&a==&b)
         return true;
     return a.getElementType()==b.getElementType();
 }
 
-bool operator==(const Structure& a, const Structure& b)
+bool compare(const Structure& a, const Structure& b)
 {
     if(&a==&b)
         return true;
@@ -101,12 +101,12 @@ bool operator==(const Structure& a, const Structure& b)
     return std::equal( an.begin(), an.end(), bn.begin() );
 }
 
-bool operator==(const StructureArray& a, const StructureArray& b)
+bool compare(const StructureArray& a, const StructureArray& b)
 {
     return *(a.getStructure().get())==*(b.getStructure().get());
 }
 
-bool operator==(const Union& a, const Union& b)
+bool compare(const Union& a, const Union& b)
 {
     if(&a==&b)
         return true;
@@ -128,12 +128,12 @@ bool operator==(const Union& a, const Union& b)
     return std::equal( an.begin(), an.end(), bn.begin() );
 }
 
-bool operator==(const UnionArray& a, const UnionArray& b)
+bool compare(const UnionArray& a, const UnionArray& b)
 {
     return *(a.getUnion().get())==*(b.getUnion().get());
 }
 
-bool operator==(const BoundedString& a, const BoundedString& b)
+bool compare(const BoundedString& a, const BoundedString& b)
 {
     if(&a==&b)
         return true;

--- a/testApp/misc/testSerialization.cpp
+++ b/testApp/misc/testSerialization.cpp
@@ -24,6 +24,8 @@
 #include <pv/noDefaultMethods.h>
 #include <pv/byteBuffer.h>
 #include <pv/convert.h>
+#include <pv/pvUnitTest.h>
+#include <pv/current_function.h>
 
 #include <pv/standardField.h>
 
@@ -629,6 +631,8 @@ void testStructureId() {
 
 void serializationFieldTest(FieldConstPtr const & field)
 {
+    testShow()<<CURRENT_FUNCTION<<"\n"<<field;
+
 	buffer->clear();
 
 	// serialize
@@ -639,7 +643,7 @@ void serializationFieldTest(FieldConstPtr const & field)
 
 	FieldConstPtr deserializedField = getFieldCreate()->deserialize(buffer, control);
 
-	// must equal
+    testShow()<<" after "<<(void*)field.get()<<" == "<<(void*)deserializedField.get();
 	testOk1(*field == *deserializedField);
 }
 

--- a/testApp/pv/Makefile
+++ b/testApp/pv/Makefile
@@ -65,3 +65,6 @@ TESTS += testFieldBuilder
 TESTPROD_HOST += testValueBuilder
 testValueBuilder_SRCS += testValueBuilder.cpp
 TESTS += testValueBuilder
+
+TESTPROD_Linux += performstruct
+performstruct_SRCS += performstruct.cpp

--- a/testApp/pv/performstruct.cpp
+++ b/testApp/pv/performstruct.cpp
@@ -1,0 +1,115 @@
+// Attempt to qualtify the effects of de-duplication on the time need to allocate a PVStructure
+#include <stdlib.h>
+#include <stdio.h>
+#include <time.h>
+#include <math.h>
+
+#include <testMain.h>
+#include <epicsUnitTest.h>
+
+#include <pv/current_function.h>
+#include <pv/pvData.h>
+#include <pv/standardField.h>
+
+namespace {
+
+namespace pvd = epics::pvData;
+
+struct TimeIt {
+    struct timespec m_start;
+    double sum, sum2;
+    size_t count;
+    TimeIt() { reset(); }
+    void reset() {
+        sum = sum2 = 0.0;
+        count = 0;
+    }
+    void start() {
+        clock_gettime(CLOCK_MONOTONIC, &m_start);
+    }
+    void end() {
+        struct timespec end;
+        clock_gettime(CLOCK_MONOTONIC, &end);
+        double diff = (end.tv_sec-m_start.tv_sec) + (end.tv_nsec-m_start.tv_nsec)*1e-9;
+        sum += diff;
+        sum2 += diff*diff;
+        count++;
+    }
+    void report(const char *unit ="s", double mult=1.0) const {
+        double mean = sum/count;
+        double mean2 = sum2/count;
+        double std = sqrt(mean2 - mean*mean);
+        printf("# %zu sample   %f +- %f %s\n", count, mean/mult, std/mult, unit);
+    }
+};
+
+void buildMiss()
+{
+    testDiag("%s", CURRENT_FUNCTION);
+    TimeIt record;
+
+    pvd::FieldCreatePtr create(pvd::getFieldCreate());
+    pvd::StandardFieldPtr standard(pvd::getStandardField());
+
+    for(size_t i=0; i<1000; i++) {
+        // unique name each time to (partially) defeat caching
+        char buf[10];
+        sprintf(buf, "field%zu", i);
+
+        record.start();
+
+        pvd::FieldConstPtr fld(create->createFieldBuilder()
+                               ->setId(buf)
+                               ->add("value", pvd::pvInt)
+                               ->addNestedStructure(buf)
+                                   ->add("value", pvd::pvString)
+                               ->endNested()
+                               ->add("display", standard->display())
+                               ->createStructure());
+        record.end();
+    }
+
+    record.report("us", 1e-6);
+}
+
+void buildHit()
+{
+    testDiag("%s", CURRENT_FUNCTION);
+    TimeIt record;
+
+    pvd::FieldCreatePtr create(pvd::getFieldCreate());
+    pvd::StandardFieldPtr standard(pvd::getStandardField());
+
+    pvd::FieldConstPtr fld(create->createFieldBuilder()
+                           ->add("value", pvd::pvInt)
+                           ->addNestedStructure("foo")
+                               ->add("field", pvd::pvString)
+                           ->endNested()
+                           ->add("display", standard->display())
+                           ->createStructure());
+
+    for(size_t i=0; i<1000; i++) {
+
+        record.start();
+
+        pvd::FieldConstPtr fld(create->createFieldBuilder()
+                               ->add("value", pvd::pvInt)
+                               ->addNestedStructure("foo")
+                                   ->add("field", pvd::pvString)
+                               ->endNested()
+                               ->add("display", standard->display())
+                               ->createStructure());
+        record.end();
+    }
+
+    record.report("us", 1e-6);
+}
+
+} // namespace
+
+MAIN(performStruct) {
+    testPlan(0);
+    buildMiss();
+    buildHit();
+    return testDone();
+}

--- a/testApp/pv/testFieldBuilder.cpp
+++ b/testApp/pv/testFieldBuilder.cpp
@@ -324,8 +324,8 @@ void test_extendStructure()
               <<"amended: "<<amended
               <<"expected: "<<expected;
 
-    testNotEqual(static_cast<const void*>(amended.get()),
-                 static_cast<const void*>(expected.get()));
+    testEqual(static_cast<const void*>(amended.get()),
+              static_cast<const void*>(expected.get()));
     testEqual(*amended, *expected);
 
     testThrows(std::runtime_error,


### PR DESCRIPTION
In an effort to make Field (aka type) comparison cheap, so that it can be done more often, use a global hash table to prevent duplicate instances of Field (and associated sub-classes).  ```operator==``` for Field becomes simple pointer comparison (the existing comparison is renamed to ```epics::pvData::compare()```).

This does make Field creation more expensive, but this is not something which a well behaved program should do frequently (after startup).

Hashing is done with the simple (though inefficient) expedient of applying ```epicsStrHash()``` to the output of ```operator<<```.