### PR TITLE
add PVRequestMapper

### DIFF
--- a/src/copy/Makefile
+++ b/src/copy/Makefile
@@ -7,4 +7,5 @@ INC += pv/pvCopy.h
 
 LIBSRCS += createRequest.cpp
 LIBSRCS += requestmask.cpp
+LIBSRCS += requestmapper.cpp
 LIBSRCS += pvCopy.cpp

--- a/src/copy/pv/createRequest.h
+++ b/src/copy/pv/createRequest.h
@@ -8,9 +8,11 @@
 #define CREATEREQUEST_H
 #include <string>
 #include <sstream>
+#include <vector>
 
 #include <pv/pvData.h>
 #include <pv/lock.h>
+#include <pv/bitSet.h>
 
 #include <shareLib.h>
 
@@ -81,6 +83,168 @@ epicsShareExtern
 BitSet extractRequestMask(const PVStructure::const_shared_pointer& type,
                           const PVStructure::const_shared_pointer& pvRequestMask,
                           bool expand = true);
+
+/** Helper for implementations of epics::pvAccess::ChannelProvider in interpreting the
+ *  'field' substructure of a pvRequest.
+ *  Copies between an internal (base) Structure, and a client/user visible (requested) Structure.
+ *
+ * @note PVRequestMapper is not re-entrant.  It is copyable and swap()able.
+ */
+class epicsShareClass PVRequestMapper {
+public:
+    enum mode_t {
+        /** Masking mode.
+         *
+         * Requested Structure is identical to Base.
+         * The 'field' substructure of the provided pvRequest is used to construct a BitSet
+         * where the bits corresponding to the "selected" fields are set.  This mask can be
+         * access via. requestedMask().  The copy* and mask* methods operate only
+         * on "selected" fields.
+         */
+        Mask,
+        /** Slice mode
+         *
+         * The Requested Structure is a strict sub-set of the Base Structure containing
+         * those fields "selected" by the 'field' substructure of the provided pvRequest.
+         */
+        Slice,
+    };
+
+    PVRequestMapper();
+    //! @see compute()
+    PVRequestMapper(const PVStructure& base,
+                    const PVStructure& pvRequest,
+                    mode_t mode = Mask);
+
+    //! return to state of default ctor
+    void reset();
+
+    //! @returns the Structure of the PVStructure previously passed to compute().  NULL if never computed()'d
+    inline const StructureConstPtr& base() const { return typeBase; }
+    //! @returns the Structure which is the selected sub-set of the base Structure.  NULL if never computed()'d
+    inline const StructureConstPtr& requested() const { return typeRequested; }
+
+    /** A mask of all fields in the base structure which are also in the requested structure,
+     *  and any parent/structure "compress" bits.  eg. bit 0 is always set.
+     *
+     @code
+     PVRequestMapper mapper(...);
+     ...
+     BitSet changed = ...; // a base changed mask
+     bool wouldcopy = changed.logical_and(mapper.requestedMask());
+     // wouldcopy==false means that copyBaseToRequested(..., changed, ...) would be a no-op
+     @endcode
+     *
+     * eg. allows early detection of empty monitor updates.
+     */
+    inline const BitSet& requestedMask() const { return maskRequested; }
+
+    //! @returns A new instance of the requested() Structure
+    PVStructurePtr buildRequested() const;
+    //! @returns A new instance of the base() Structure
+    PVStructurePtr buildBase() const;
+
+    /** (re)compute the selected subset of provided base structure.
+     * @param base A full base structure.
+     *             Must be "top level" (field offset zero).
+     * @param pvRequest The user/client provided request modifier
+     * @param mode Control how the mapping is constructed.  @see mode_t for a description of mapping modes.
+     *
+     * @post Updates warnings()
+     * @throws std::runtime_error For errors involving invalid pvRequest
+     * @throws std::logic_error if the provided base is not a "top level" PVStructure.
+     */
+    void compute(const PVStructure& base,
+                 const PVStructure& pvRequest,
+                 mode_t mode = Mask);
+
+    //! After compute(), check if !warnings().empty()
+    inline const std::string& warnings() const { return messages; }
+
+    /** Copy field values from Base structure into Requested structure
+     *
+     * @param base An instance of the base Structure.  Field values are copied from it.
+     *                Need not be the same instance passed to compute().
+     * @param baseMask A bit mask selecting those base fields to copy.
+     * @param request An instance of the requested() Structure.  Field values are copied to it.
+     * @param requestMask A bit mask indicating which requested fields were copied.
+     *                    BitSet::clear() is not called.
+     */
+    void copyBaseToRequested(
+            const PVStructure& base,
+            const BitSet& baseMask,
+            PVStructure& request,
+            BitSet& requestMask
+    ) const;
+
+    /** Copy field values into Base structure from Requested structure
+     *
+     * @param base An instance of the base Structure.  Field values are copied into it.
+     *             Need not be the same instance passed to compute().
+     * @param baseMask A bit mask indicating which base fields were copied.
+     *                 BitSet::clear() is not called.
+     * @param request An instance of the requested() Structure.  Field values are copied from it.
+     * @param requestMask A bit mask selecting those requested fields to copy.
+     */
+    void copyBaseFromRequested(
+            PVStructure& base,
+            BitSet& baseMask,
+            const PVStructure& request,
+            const BitSet& requestMask
+    ) const;
+
+    //! Translate Base bit mask into requested bit mask.
+    //! BitSet::clear() is not called.
+    inline void maskBaseToRequested(
+            const BitSet& baseMask,
+            BitSet& requestMask
+            ) const
+    { _mapMask(baseMask, requestMask, false); }
+
+    //! Translate requested bit mask into base bit mask.
+    //! BitSet::clear() is not called.
+    inline void maskBaseFromRequested(
+            BitSet& baseMask,
+            const BitSet& requestMask
+            ) const
+    { _mapMask(requestMask, baseMask, true); }
+
+    //! Exchange contents of two mappers.  O(0) and never throws.
+    void swap(PVRequestMapper& other);
+
+private:
+    bool _compute(const PVStructure& base, const PVStructure& pvReq,
+                  FieldBuilderPtr& builder, bool keepids, unsigned depth);
+
+    void _map(const PVStructure& src,
+              const BitSet& maskSrc,
+              PVStructure& dest,
+              BitSet& maskDest,
+              bool dir_r2b) const;
+    void _mapMask(const BitSet& maskSrc,
+                  BitSet& maskDest,
+                  bool dir_r2b) const;
+
+    StructureConstPtr typeBase, typeRequested;
+    BitSet maskRequested;
+    // Map between field offsets of base and requested Structures.
+    // Include all fields, both leaf and sub-structure.
+    struct Mapping {
+        size_t to; // offset in destination Structure
+        BitSet tomask,   // if !leaf these are the other bits in the destination mask to changed
+               frommask; // if !leaf these are the other bits in the source mask to be copied
+        bool valid; // only true in (sparse) base -> requested mapping
+        bool leaf; // not a (sub)Structure?
+        Mapping() :valid(false) {}
+        Mapping(size_t to, bool leaf) :to(to), valid(true), leaf(leaf) {}
+    };
+    typedef std::vector<Mapping> mapping_t;
+    mapping_t base2req, req2base;
+
+    std::string messages;
+
+    mutable BitSet scratch; // avoid temporary allocs.  (we aren't re-entrant!)
+};
 
 }}
 

--- a/src/copy/requestmapper.cpp
+++ b/src/copy/requestmapper.cpp
@@ -1,0 +1,328 @@
+/*
+ * Copyright information and license terms for this software can be
+ * found in the file LICENSE that is included with the distribution
+ */
+
+#include <sstream>
+
+#include <epicsAssert.h>
+#include <epicsTypes.h>
+#include <epicsVersion.h>
+#include <epicsConvert.h>
+#include <epicsAssert.h>
+#include <epicsMutex.h>
+#include <epicsGuard.h>
+
+#define epicsExportSharedSymbols
+#include <pv/createRequest.h>
+#include <pv/epicsException.h>
+#include <pv/bitSet.h>
+
+// Our arbitrary limit on pvRequest structure depth to bound stack usage during recursion
+static const unsigned maxDepth = 5;
+
+namespace epics{namespace pvData {
+
+PVRequestMapper::PVRequestMapper() {}
+
+PVRequestMapper::PVRequestMapper(const PVStructure &base,
+                                 const PVStructure &pvRequest,
+                                 mode_t mode)
+{
+    compute(base, pvRequest, mode);
+}
+
+PVStructurePtr PVRequestMapper::buildRequested() const
+{
+    if(!typeRequested)
+        THROW_EXCEPTION2(std::logic_error, "No mapping compute()d");
+    return getPVDataCreate()->createPVStructure(typeRequested);
+}
+
+PVStructurePtr PVRequestMapper::buildBase() const
+{
+    if(!typeBase)
+        THROW_EXCEPTION2(std::logic_error, "No mapping compute()d");
+    return getPVDataCreate()->createPVStructure(typeBase);
+}
+
+void PVRequestMapper::compute(const PVStructure &base,
+                              const PVStructure &pvRequest,
+                              mode_t mode)
+{
+    if(base.getFieldOffset()!=0)
+        THROW_EXCEPTION2(std::logic_error, "Mapper must be used with top level PVStructure");
+
+    bool ok = true;
+
+    // we want to be transactional, which requires a second copy of everything.
+    PVRequestMapper temp;
+
+    // whether to preserve IDs of partial structures.
+    bool keepids = false;
+    PVScalar::const_shared_pointer pbp(pvRequest.getSubField<PVScalar>("record._options.keepIDs"));
+    try {
+        if(pbp) keepids = pbp->getAs<boolean>();
+    }catch(std::runtime_error& e){
+        std::ostringstream msg;
+        msg<<"Can't parse keepIDs : '"<<e.what()<<"' ";
+        temp.messages+=msg.str();
+    }
+
+    PVStructure::const_shared_pointer fields(pvRequest.getSubField<PVStructure>("field"));
+    if(!fields || fields->getPVFields().empty()) {
+        // not selection, or empty selection, treated as select all
+        temp.typeBase = temp.typeRequested = base.getStructure();
+
+        for(size_t i=1, N=base.getNextFieldOffset(); i<N; i++)
+            temp.maskRequested.set(i);
+
+    } else {
+        FieldBuilderPtr builder(getFieldCreate()->createFieldBuilder());
+
+        if(keepids)
+            builder = builder->setId(base.getStructure()->getID());
+
+        ok &= temp._compute(base, *fields, builder, keepids, 0); // fills in builder
+
+        temp.typeBase = base.getStructure();
+        temp.typeRequested = builder->createStructure();
+        // possible that typeBase==typeRequested if all fields explicitly selected
+    }
+
+    if(mode==Mask) {
+        // short circuit use of masked Structure, but keep maskRequested
+        temp.typeRequested = temp.typeBase;
+    }
+
+    {
+        PVStructurePtr proto(getPVDataCreate()->createPVStructure(temp.typeRequested));
+
+        // base -> request may be sparce mapping
+        temp.base2req.resize(base.getNextFieldOffset());
+        // request -> base is dense mapping
+        temp.req2base.resize(proto->getNextFieldOffset());
+
+        // special handling for whole structure mapping.  in part because getSubField(0) isn't allowed
+        temp.base2req[0] = Mapping(0, false);
+        temp.req2base[0] = Mapping(0, false);
+
+        // Iterate prototype of requested to map with base field offsets.
+        // which is handled as a special case below.
+        // We also don't try to prevent redundant copies if both leaf and compress bits are set.
+        for(size_t r=1, N=proto->getNextFieldOffset(); r<N; r++) {
+            PVField::const_shared_pointer fld_req(proto->getSubFieldT(r)),
+                    fld_base(base.getSubFieldT(fld_req->getFullName()));
+            const size_t b = fld_base->getFieldOffset();
+
+            if(!temp.requestedMask().get(b))
+                continue;
+
+            bool leaf = fld_base->getField()->getType()!=structure;
+
+            // initialize mapping when our bit is set
+            temp.base2req[b] = Mapping(r, leaf);
+            temp.req2base[r] = Mapping(b, leaf);
+
+            // add ourself to all "compress" bit mappings of enclosing structures
+            for(const PVStructure *parent = fld_req->getParent(); parent; parent = parent->getParent()) {
+                temp.req2base[parent->getFieldOffset()].tomask  .set(b);
+                temp.req2base[parent->getFieldOffset()].frommask.set(r);
+            }
+
+            for(const PVStructure *parent = fld_base->getParent(); parent; parent = parent->getParent()) {
+                temp.base2req[parent->getFieldOffset()].tomask  .set(r);
+                temp.base2req[parent->getFieldOffset()].frommask.set(b);
+            }
+        }
+    }
+
+    temp.maskRequested.set(0);
+
+    if(temp.maskRequested.nextSetBit(1)==-1) {
+        ok = false;
+        temp.messages+="Empty field selection";
+    }
+
+    if(!ok)
+        throw std::runtime_error(temp.messages);
+
+    swap(temp);
+}
+
+bool PVRequestMapper::_compute(const PVStructure& base, const PVStructure& pvReq,
+                               FieldBuilderPtr& builder, bool keepids, unsigned depth)
+{
+    bool ok = true;
+    const StringArray& reqNames = pvReq.getStructure()->getFieldNames();
+
+    for(size_t i=0, N=reqNames.size(); i<N; i++) {
+        // iterate through requested fields
+
+        PVField::const_shared_pointer subtype(base.getSubField(reqNames[i]));
+        const FieldConstPtr& subReq = pvReq.getStructure()->getFields()[i];
+
+        if(subReq->getType()!=structure) {
+            // pvRequest .field was not properly composed
+            std::ostringstream msg;
+            // not a great warning message as it doesn't distinguish 'a.value' from 'b.value',
+            // but getFullName() whould prefix with 'field.', which would probably cause
+            // more frequent confusion...
+            msg<<"request invalid '"<<pvReq.getStructure()->getFieldNames()[i]<<"' ";
+            messages+=msg.str();
+            ok = false;
+
+        } else if(!subtype) {
+            // requested field does not actually exist in base
+            std::ostringstream msg;
+            msg<<"No field '"<<pvReq.getStructure()->getFieldNames()[i]<<"' ";
+            messages+=msg.str();
+
+        } else if(depth>=maxDepth // exceeds max recursion depth
+                  || subtype->getField()->getType()!=structure // requested field is a leaf
+                  || static_cast<const Structure&>(*subReq).getFieldNames().empty() // requests all sub-fields
+                  )
+        {
+            // just add the whole thing
+            builder = builder->add(reqNames[i], subtype->getField());
+            for(size_t j=subtype->getFieldOffset(), N=subtype->getNextFieldOffset(); j<N; j++)
+                maskRequested.set(j);
+
+            if(subtype->getField()->getType()!=structure
+                    && !static_cast<const Structure&>(*subReq).getFieldNames().empty())
+            {
+                // attempt to select below a leaf field
+                std::ostringstream msg;
+                msg<<"Leaf field '"<<pvReq.getFullName()<<"' ";
+                messages+=msg.str();
+            } else if(depth>=maxDepth) {
+                std::ostringstream msg;
+                msg<<"selection truncated at '"<<pvReq.getFullName()<<"' ";
+                messages+=msg.str();
+            }
+
+        } else {
+            // recurse into sub-structure
+            const PVStructure& substruct = static_cast<const PVStructure&>(*subtype);
+
+            builder = builder->addNestedStructure(reqNames[i]);
+            maskRequested.set(substruct.getFieldOffset());
+
+            if(keepids)
+                builder = builder->setId(substruct.getStructure()->getID());
+
+            _compute(substruct,
+                     static_cast<const PVStructure&>(*pvReq.getPVFields()[i]),
+                     builder, keepids, depth+1u);
+
+            builder = builder->endNested();
+        }
+    }
+    return ok;
+}
+
+void PVRequestMapper::copyBaseToRequested(
+        const PVStructure& base,
+        const BitSet& baseMask,
+        PVStructure& request,
+        BitSet& requestMask
+) const {
+    assert(base.getStructure()==typeBase);
+    assert(request.getStructure()==typeRequested);
+    _map(base, baseMask, request, requestMask, false);
+}
+
+void PVRequestMapper::copyBaseFromRequested(
+        PVStructure& base,
+        BitSet& baseMask,
+        const PVStructure& request,
+        const BitSet& requestMask
+) const {
+    assert(base.getStructure()==typeBase);
+    assert(request.getStructure()==typeRequested);
+    _map(request, requestMask, base, baseMask, true);
+}
+
+void PVRequestMapper::_map(const PVStructure& src, const BitSet& maskSrc,
+                           PVStructure& dest, BitSet& maskDest,
+                           bool dir_r2b) const
+{
+    {
+        scratch = maskSrc;
+        const mapping_t& map = dir_r2b ? req2base : base2req;
+
+        assert(map.size()==src.getNumberFields());
+
+        for(int32 i=scratch.nextSetBit(0), N=map.size(); i>=0 && i<N; i=scratch.nextSetBit(i+1)) {
+            const Mapping& M = map[i];
+            if(!M.valid) {
+                assert(!dir_r2b); // only base -> requested mapping can have holes
+
+            } else if(M.leaf) {
+                // just copy
+                dest.getSubFieldT(M.to)->copy(*src.getSubFieldT(i));
+                maskDest.set(M.to);
+
+            } else {
+                // set bits of all sub-fields (in requested structure)
+                // these indicies are always >i
+                scratch |= M.frommask;
+
+                // we will also set the individual bits, but if a compress bit is set in the input,
+                // then set the corresponding bit in the output.
+                maskDest.set(M.to);
+            }
+        }
+    }
+}
+
+void PVRequestMapper::_mapMask(const BitSet& maskSrc,
+                               BitSet& maskDest,
+                               bool dir_r2b) const
+{
+    if(maskSrc.isEmpty()) {
+        // no-op
+
+    } else {
+        const mapping_t& map = dir_r2b ? req2base : base2req;
+
+        for(int32 i=maskSrc.nextSetBit(0), N=map.size(); i>=0 && i<N; i=maskSrc.nextSetBit(i+1)) {
+            const Mapping& M = map[i];
+            if(!M.valid) {
+                assert(!dir_r2b); // only base -> requested mapping can have holes
+
+            } else {
+                maskDest.set(M.to);
+
+                if(!M.leaf) {
+                    maskDest |= M.tomask;
+                }
+            }
+        }
+    }
+
+}
+
+void PVRequestMapper::swap(PVRequestMapper& other)
+{
+    typeBase.swap(other.typeBase);
+    typeRequested.swap(other.typeRequested);
+    maskRequested.swap(other.maskRequested);
+    base2req.swap(other.base2req);
+    req2base.swap(other.req2base);
+    messages.swap(other.messages);
+    scratch.swap(other.scratch); // paranoia
+}
+
+void PVRequestMapper::reset()
+{
+    typeBase.reset();
+    typeRequested.reset();
+    maskRequested.clear();
+    base2req.clear();
+    req2base.clear();
+    messages.clear();
+    scratch.clear(); // paranoia
+}
+
+}} //namespace epics::pvData

--- a/testApp/copy/testCreateRequest.cpp
+++ b/testApp/copy/testCreateRequest.cpp
@@ -434,14 +434,380 @@ static void testMask()
               .set(V->getSubField("A")->getFieldOffset()));
 }
 
+static
+void testMapper(PVRequestMapper::mode_t mode)
+{
+    testDiag("=== %s mode==%d", CURRENT_FUNCTION, (int)mode);
+    {
+        testDiag("Map full structure");
+
+        PVStructurePtr base(getPVDataCreate()->createPVStructure(maskingType));
+        PVRequestMapper mapper(*base, *createRequest(""), mode);
+
+        testEqual(mapper.requested(), maskingType);
+
+        testEqual(mapper.requestedMask(), BitSet().set(0)
+                  .set(base->getSubFieldT("A")->getFieldOffset())
+                  .set(base->getSubFieldT("B")->getFieldOffset())
+                  .set(base->getSubFieldT("C")->getFieldOffset())
+                  .set(base->getSubFieldT("C.D")->getFieldOffset())
+                  .set(base->getSubFieldT("C.E")->getFieldOffset())
+                  .set(base->getSubFieldT("C.E.F")->getFieldOffset()));
+
+        PVStructurePtr req(getPVDataCreate()->createPVStructure(mapper.requested()));
+
+        base->getSubFieldT<PVInt>("A")->put(1);
+        base->getSubFieldT<PVInt>("B")->put(42);
+
+        BitSet output;
+        mapper.copyBaseToRequested(*base, BitSet().set(0), *req, output);
+
+        testFieldEqual<PVInt>(req, "A", 1);
+        testFieldEqual<PVInt>(req, "B", 42);
+
+        req->getSubFieldT<PVInt>("A")->put(2);
+        req->getSubFieldT<PVInt>("B")->put(43);
+
+        mapper.copyBaseFromRequested(*base, output, *req, BitSet().set(0));
+
+        testFieldEqual<PVInt>(req, "A", 2);
+        testFieldEqual<PVInt>(req, "B", 43);
+        testEqual(mapper.requestedMask(), BitSet().set(0).set(1).set(2).set(3).set(4).set(5).set(6));
+    }
+    {
+        testDiag("Map single leaf field");
+
+        PVStructurePtr base(getPVDataCreate()->createPVStructure(maskingType));
+        PVRequestMapper mapper(*base, *createRequest("field(B)"), mode);
+
+        if(mode==PVRequestMapper::Slice)
+            testNotEqual(mapper.requested(), maskingType);
+        else
+            testEqual(mapper.requested(), maskingType);
+
+        testEqual(mapper.requestedMask(), BitSet().set(0)
+                  .set(base->getSubFieldT("B")->getFieldOffset()));
+
+        PVStructurePtr req(getPVDataCreate()->createPVStructure(mapper.requested()));
+
+        if(mode==PVRequestMapper::Slice)
+            testOk1(!req->getSubField("A"));
+
+        base->getSubFieldT<PVScalar>("A")->putFrom<int32>(11);
+        base->getSubFieldT<PVScalar>("B")->putFrom<int32>(42);
+
+        BitSet output;
+        mapper.copyBaseToRequested(*base, BitSet().set(0), *req, output);
+
+        if(mode!=PVRequestMapper::Slice)
+            testFieldEqual<PVInt>(req, "A", 0);
+        testFieldEqual<PVInt>(req, "B", 42);
+
+        req->getSubFieldT<PVScalar>("B")->putFrom<int32>(43);
+
+        mapper.copyBaseFromRequested(*base, output, *req, BitSet().set(0));
+
+        testFieldEqual<PVInt>(req, "B", 43);
+        testEqual(mapper.requestedMask(), BitSet().set(0)
+                  .set(base->getSubFieldT("B")->getFieldOffset()));
+
+        BitSet cmp;
+        mapper.maskBaseToRequested(BitSet().set(base->getSubFieldT("B")->getFieldOffset()), cmp);
+        testEqual(cmp, BitSet()
+                  .set(req->getSubFieldT("B")->getFieldOffset()));
+
+        cmp.clear();
+        mapper.maskBaseFromRequested(cmp, BitSet()
+                                   .set(req->getSubFieldT("B")->getFieldOffset()));
+        testEqual(cmp, BitSet()
+                  .set(base->getSubFieldT("B")->getFieldOffset()));
+    }
+    {
+        testDiag("Map two sub-fields");
+
+        PVStructurePtr base(getPVDataCreate()->createPVStructure(maskingType));
+        PVRequestMapper mapper(*base, *createRequest("B,C.D"), mode);
+
+        if(mode==PVRequestMapper::Slice)
+            testNotEqual(mapper.requested(), maskingType);
+        else
+            testEqual(mapper.requested(), maskingType);
+
+        testEqual(mapper.requestedMask(), BitSet().set(0)
+                  .set(base->getSubFieldT("B")->getFieldOffset())
+                  .set(base->getSubFieldT("C")->getFieldOffset())
+                  .set(base->getSubFieldT("C.D")->getFieldOffset()));
+
+        PVStructurePtr req(getPVDataCreate()->createPVStructure(mapper.requested()));
+
+        if(mode==PVRequestMapper::Slice)
+            testOk1(!req->getSubField("A"));
+
+        base->getSubFieldT<PVScalar>("A")->putFrom<int32>(11);
+        base->getSubFieldT<PVScalar>("B")->putFrom<int32>(1);
+        base->getSubFieldT<PVScalar>("C.D")->putFrom<int32>(42);
+
+        BitSet output;
+        mapper.copyBaseToRequested(*base, BitSet().set(0), *req, output);
+
+        if(mode!=PVRequestMapper::Slice)
+            testFieldEqual<PVInt>(req, "A", 0);
+        testFieldEqual<PVInt>(req, "B", 1);
+        testFieldEqual<PVInt>(req, "C.D", 42);
+
+        req->getSubFieldT<PVScalar>("B")->putFrom<int32>(2);
+        req->getSubFieldT<PVScalar>("C.D")->putFrom<int32>(43);
+
+        mapper.copyBaseFromRequested(*base, output, *req, BitSet().set(0));
+
+        testFieldEqual<PVInt>(req, "B", 2);
+        testFieldEqual<PVInt>(req, "C.D", 43);
+        testEqual(mapper.requestedMask(), BitSet().set(0)
+                  .set(base->getSubFieldT("B")->getFieldOffset())
+                  .set(base->getSubFieldT("C")->getFieldOffset())
+                  .set(base->getSubFieldT("C.D")->getFieldOffset()));
+    }
+    {
+        testDiag("Map entire sub-structure");
+
+        PVStructurePtr base(getPVDataCreate()->createPVStructure(maskingType));
+        PVRequestMapper mapper(*base, *createRequest("field(C.E)"), mode);
+
+        if(mode==PVRequestMapper::Slice)
+            testNotEqual(mapper.requested(), maskingType);
+        else
+            testEqual(mapper.requested(), maskingType);
+
+        testEqual(mapper.requestedMask(), BitSet().set(0)
+                  .set(base->getSubFieldT("C")->getFieldOffset())
+                  .set(base->getSubFieldT("C.E")->getFieldOffset())
+                  .set(base->getSubFieldT("C.E.F")->getFieldOffset()));
+
+
+        PVStructurePtr req(getPVDataCreate()->createPVStructure(mapper.requested()));
+
+        if(mode==PVRequestMapper::Slice)
+            testOk1(!req->getSubField("A"));
+
+        base->getSubFieldT<PVScalar>("A")->putFrom<int32>(11);
+        base->getSubFieldT<PVScalar>("C.E.F")->putFrom<int32>(42);
+
+        BitSet output;
+        mapper.copyBaseToRequested(*base, BitSet().set(0), *req, output);
+
+        if(mode!=PVRequestMapper::Slice)
+            testFieldEqual<PVInt>(req, "A", 0);
+        testFieldEqual<PVInt>(req, "C.E.F", 42);
+
+        req->getSubFieldT<PVScalar>("C.E.F")->putFrom<int32>(43);
+
+        mapper.copyBaseFromRequested(*base, output, *req, BitSet().set(0));
+
+        testFieldEqual<PVInt>(req, "C.E.F", 43);
+        testEqual(mapper.requestedMask(), BitSet().set(0)
+                  .set(base->getSubFieldT("C")->getFieldOffset())
+                  .set(base->getSubFieldT("C.E")->getFieldOffset())
+                  .set(base->getSubFieldT("C.E.F")->getFieldOffset()));
+
+        BitSet cmp;
+        mapper.maskBaseToRequested(BitSet()
+                                   .set(base->getSubFieldT("C")->getFieldOffset()), cmp);
+        testEqual(cmp, BitSet()
+                  .set(req->getSubFieldT("C")->getFieldOffset())
+                  .set(req->getSubFieldT("C.E")->getFieldOffset())
+                  .set(req->getSubFieldT("C.E.F")->getFieldOffset()));
+
+        cmp.clear();
+        mapper.maskBaseFromRequested(cmp, BitSet()
+                                   .set(req->getSubFieldT("C")->getFieldOffset()));
+        testEqual(cmp, BitSet()
+                  .set(base->getSubFieldT("C")->getFieldOffset())
+                  .set(base->getSubFieldT("C.E")->getFieldOffset())
+                  .set(base->getSubFieldT("C.E.F")->getFieldOffset()));
+    }
+}
+
+struct MapperMask {
+    PVStructurePtr base, req;
+    BitSet bmask, rmask;
+    PVRequestMapper mapper;
+
+    MapperMask(PVRequestMapper::mode_t mode) {
+        base = getPVDataCreate()->createPVStructure(maskingType);
+        mapper.compute(*base, *createRequest("field(B,C.E)"), mode);
+        req = getPVDataCreate()->createPVStructure(mapper.requested());
+        reset();
+    }
+
+    void reset() {
+        base->getSubFieldT<PVScalar>("B")->putFrom<int32>(1);
+        base->getSubFieldT<PVScalar>("C.E.F")->putFrom<int32>(3);
+        req->getSubFieldT<PVScalar>("B")->putFrom<int32>(11);
+        req->getSubFieldT<PVScalar>("C.E.F")->putFrom<int32>(13);
+    }
+
+    void check(int32 bB, int32 bCEF, int32 rB, int32 rCEF) {
+        testFieldEqual<PVInt>(base, "B", bB);
+        testFieldEqual<PVInt>(base, "C.E.F", bCEF);
+        testFieldEqual<PVInt>(req, "B", rB);
+        testFieldEqual<PVInt>(req, "C.E.F", rCEF);
+    }
+
+    void testEmptyMaskB2R() {
+        mapper.copyBaseToRequested(*base, bmask, *req, rmask);
+        check(1, 3, 11, 13);
+        testEqual(bmask, BitSet());
+        testEqual(rmask, BitSet());
+    }
+
+    void testEmptyMaskR2B() {
+        mapper.copyBaseFromRequested(*base, bmask, *req, rmask);
+        check(1, 3, 11, 13);
+        testEqual(bmask, BitSet());
+        testEqual(rmask, BitSet());
+    }
+
+    void testAllMaskB2R() {
+        bmask.set(0);
+        mapper.copyBaseToRequested(*base, bmask, *req, rmask);
+        check(1, 3, 1, 3);
+        testEqual(rmask, BitSet()
+                  .set(0)
+                  .set(req->getSubFieldT("B")->getFieldOffset())
+                  .set(req->getSubFieldT("C")->getFieldOffset())
+                  .set(req->getSubFieldT("C.E")->getFieldOffset())
+                  .set(req->getSubFieldT("C.E.F")->getFieldOffset()));
+    }
+
+    void testAllMaskR2B() {
+        rmask.set(0);
+        mapper.copyBaseFromRequested(*base, bmask, *req, rmask);
+        check(11, 13, 11, 13);
+        testEqual(bmask, BitSet()
+                  .set(0)
+                  .set(base->getSubFieldT("B")->getFieldOffset())
+                  .set(base->getSubFieldT("C")->getFieldOffset())
+                  .set(base->getSubFieldT("C.E")->getFieldOffset())
+                  .set(base->getSubFieldT("C.E.F")->getFieldOffset()));
+    }
+
+    void testMaskOneB2R() {
+        bmask.set(base->getSubFieldT("B")->getFieldOffset());
+        mapper.copyBaseToRequested(*base, bmask, *req, rmask);
+        check(1, 3, 1, 13);
+        testEqual(rmask, BitSet()
+                  .set(req->getSubFieldT("B")->getFieldOffset()));
+    }
+
+    void testMaskOneR2B() {
+        rmask.set(req->getSubFieldT("B")->getFieldOffset());
+        mapper.copyBaseFromRequested(*base, bmask, *req, rmask);
+        check(11, 3, 11, 13);
+        testEqual(bmask, BitSet()
+                  .set(base->getSubFieldT("B")->getFieldOffset()));
+    }
+
+    void testMaskOtherB2R() {
+        bmask.set(base->getSubFieldT("C.E.F")->getFieldOffset());
+        mapper.copyBaseToRequested(*base, bmask, *req, rmask);
+        check(1, 3, 11, 3);
+        testEqual(rmask, BitSet()
+                  .set(req->getSubFieldT("C.E.F")->getFieldOffset()));
+    }
+
+    void testMaskOtherR2B() {
+        rmask.set(req->getSubFieldT("C.E.F")->getFieldOffset());
+        mapper.copyBaseFromRequested(*base, bmask, *req, rmask);
+        check(1, 13, 11, 13);
+        testEqual(bmask, BitSet()
+                  .set(base->getSubFieldT("C.E.F")->getFieldOffset()));
+    }
+
+    void testMaskSub1B2R() {
+        bmask.set(base->getSubFieldT("C.E")->getFieldOffset());
+        mapper.copyBaseToRequested(*base, bmask, *req, rmask);
+        check(1, 3, 11, 3);
+        testEqual(rmask, BitSet()
+                  .set(req->getSubFieldT("C.E")->getFieldOffset())
+                  .set(req->getSubFieldT("C.E.F")->getFieldOffset()));
+    }
+
+    void testMaskSub1R2B() {
+        rmask.set(req->getSubFieldT("C.E")->getFieldOffset());
+        mapper.copyBaseFromRequested(*base, bmask, *req, rmask);
+        check(1, 13, 11, 13);
+        testEqual(bmask, BitSet()
+                  .set(base->getSubFieldT("C.E")->getFieldOffset())
+                  .set(base->getSubFieldT("C.E.F")->getFieldOffset()));
+    }
+
+    void testMaskSub2B2R() {
+        bmask.set(base->getSubFieldT("C")->getFieldOffset());
+        mapper.copyBaseToRequested(*base, bmask, *req, rmask);
+        check(1, 3, 11, 3);
+        testEqual(rmask, BitSet()
+                  .set(req->getSubFieldT("C")->getFieldOffset())
+                  .set(req->getSubFieldT("C.E")->getFieldOffset())
+                  .set(req->getSubFieldT("C.E.F")->getFieldOffset()));
+    }
+
+    void testMaskSub2R2B() {
+        rmask.set(req->getSubFieldT("C")->getFieldOffset());
+        mapper.copyBaseFromRequested(*base, bmask, *req, rmask);
+        check(1, 13, 11, 13);
+        testEqual(bmask, BitSet()
+                  .set(base->getSubFieldT("C")->getFieldOffset())
+                  .set(base->getSubFieldT("C.E")->getFieldOffset())
+                  .set(base->getSubFieldT("C.E.F")->getFieldOffset()));
+    }
+};
+
+void testMaskWarn()
+{
+    PVStructurePtr base(getPVDataCreate()->createPVStructure(maskingType));
+    PVRequestMapper mapper(*base, *createRequest("field(B,invalid)"), PVRequestMapper::Slice);
+
+    testEqual(mapper.warnings(), "No field 'invalid' ");
+}
+
+void testMaskErr()
+{
+    PVStructurePtr base(getPVDataCreate()->createPVStructure(maskingType));
+    testThrows(std::runtime_error, PVRequestMapper mapper(*base, *createRequest("field(invalid)"), PVRequestMapper::Slice));
+}
+
 } // namespace
 
 MAIN(testCreateRequest)
 {
-    testPlan(141);
+    testPlan(329);
     testCreateRequestInternal();
     testBadRequest();
     testMask();
+    testMapper(PVRequestMapper::Slice);
+    testMapper(PVRequestMapper::Mask);
+#undef TEST_METHOD
+#define TEST_METHOD(KLASS, METHOD) \
+    { \
+        testDiag("------- %s::%s Mask --------", #KLASS, #METHOD); \
+        { KLASS inst(PVRequestMapper::Mask); inst.METHOD(); } \
+        testDiag("------- %s::%s Slice --------", #KLASS, #METHOD); \
+        { KLASS inst(PVRequestMapper::Slice); inst.METHOD(); } \
+    }
+    TEST_METHOD(MapperMask, testEmptyMaskB2R);
+    TEST_METHOD(MapperMask, testEmptyMaskR2B);
+    TEST_METHOD(MapperMask, testAllMaskB2R);
+    TEST_METHOD(MapperMask, testAllMaskR2B);
+    TEST_METHOD(MapperMask, testMaskOneB2R);
+    TEST_METHOD(MapperMask, testMaskOneR2B);
+    TEST_METHOD(MapperMask, testMaskOtherB2R);
+    TEST_METHOD(MapperMask, testMaskOtherR2B);
+    TEST_METHOD(MapperMask, testMaskSub1B2R);
+    TEST_METHOD(MapperMask, testMaskSub1R2B);
+    TEST_METHOD(MapperMask, testMaskSub2B2R);
+    TEST_METHOD(MapperMask, testMaskSub2R2B);
+    testMaskWarn();
+    testMaskErr();
     return testDone();
 }
 


### PR DESCRIPTION
Utility for pvRequest .field mangling in ChannelProvider implementations, either my or @mrkraimer preferred schemes can be selected with an enum.  As per #51 this API is intended as a replacement of pvCopy, and the simpler extractRequestMask() I added previously.

A ```PVRequestMapper``` holds a precomputed mapping between two Structures, referred to as "Base" and "Requested".

* Base - The internal structure manipulated by server/provider logic.
* Requested - The structure seen by user/client code.

The API itself revolves around the ```PVRequestMapper::copyBaseToRequested()``` and ```PVRequestMapper::copyBaseFromRequested()``` methods which allow masked shallow copying between PVStructures of the two types.

So a minimal usage would look like

```c++
// eg. during ChannelGet setup
PVStructurePtr mybase = ...; // some server internal structure
PVStructurePtr pvRequest = ...; // A client provided request

PVRequestMapper mapper(*mybase, *pvRequest); // precompute mapping and save for later use

// ... eg. later during ChannelGet::get()

BitSet valid = ...; // those fields of mybase which may actually be sent. (eg. having non-default values)
BitSet uvalid; // mapping of bit mask onto Requested Structure
PVStructurePtr userval(mapper.buildRequested());

mapper.copyBaseToRequested(*mybase, valid, *userval, uvalid); // copying.  userval and uvalid modified
```

There are a couple of differences in behavior vs. pvCopy which I know of (and probably some I don't).

* This code will warn if requesting some non-existent fields, and only error if none of the requested fields exist.  This is intended to allow clients to request optional fields.
* By default, structures which are "Sliced"d will lose their type ID string.  This is controllable via an option eg. "record[keepIDs=true]".
* The pvRequest represented as "" is treated identically to "field()", aka. wildcard.  pvCopy treats this as an empty request (no fields).  As a side effect this makes it impossible to make an empty request.
* There is an arbitrary depth limit to pvRequest '.field' selections (currently 5 levels).  This is a safe guard of the recursive implementation.  Attempting to exceeding the depth limit selects the entire 4th level parent structure (and warns).

Currently this API has been added in the SharedPV (aka. simplified server api) in pvAccessCPP.  cf. https://github.com/mdavidsaver/pvAccessCPP/tree/inprog .  I'm planning to use it as well in QSRV, and perhaps P2P.