### PR TITLE
link with rt when using clock_gettime()

### DIFF
--- a/testApp/pv/Makefile
+++ b/testApp/pv/Makefile
@@ -68,3 +68,4 @@ TESTS += testValueBuilder
 
 TESTPROD_Linux += performstruct
 performstruct_SRCS += performstruct.cpp
+performstruct_SYS_LIBS_Linux += rt


### PR DESCRIPTION
Fixes linker error:
/opt/eldk-5.2/powerpc-e500v2/sysroots/i686-eldk-linux/usr/bin/ppce500v2-linux-gnuspe/../../libexec/ppce500v2-linux-gnuspe/gcc/powerpc-linux-gnuspe/4.6.4/ld: performstruct.o: undefined reference to symbol 'clock_gettime@@GLIBC_2.2' 
/opt/eldk-5.2/powerpc-e500v2/sysroots/i686-eldk-linux/usr/bin/ppce500v2-linux-gnuspe/../../libexec/ppce500v2-linux-gnuspe/gcc/powerpc-linux-gnuspe/4.6.4/ld: note: 'clock_gettime@@GLIBC_2.2' is defined in DSO /opt/eldk-5.2/powerpc-e500v2/sysroots/ppce500v2-linux-gnuspe/lib/librt.so.1 so try adding it to the linker command line 
