### PR TITLE
 Add FieldBuilder::build() and Field::create()

### DIFF
--- a/src/copy/createRequest.cpp
+++ b/src/copy/createRequest.cpp
@@ -318,7 +318,7 @@ struct CreateRequestImpl {
             if (!request.empty()) removeBlanks(request);
             if (request.empty())
             {
-                return pvDataCreate->createPVStructure(fieldCreate->createStructure());
+                return fieldCreate->createStructure()->build();
             }
             size_t offsetRecord = request.find("record[");
             size_t offsetField = request.find("field(");
@@ -437,7 +437,7 @@ struct CreateRequestImpl {
             }
             StructureConstPtr structure = fieldCreate->createStructure(names, fields);
             if(!structure) throw std::invalid_argument("bad request " + crequest);
-            PVStructurePtr pvStructure = pvDataCreate->createPVStructure(structure);
+            PVStructurePtr pvStructure = structure->build();
             for(size_t i=0; i<optionList.size(); ++i) {
                 OptionPair pair = optionList[i];
                 string name = pair.name;

--- a/src/copy/requestmapper.cpp
+++ b/src/copy/requestmapper.cpp
@@ -36,14 +36,14 @@ PVStructurePtr PVRequestMapper::buildRequested() const
 {
     if(!typeRequested)
         THROW_EXCEPTION2(std::logic_error, "No mapping compute()d");
-    return getPVDataCreate()->createPVStructure(typeRequested);
+    return typeRequested->build();
 }
 
 PVStructurePtr PVRequestMapper::buildBase() const
 {
     if(!typeBase)
         THROW_EXCEPTION2(std::logic_error, "No mapping compute()d");
-    return getPVDataCreate()->createPVStructure(typeBase);
+    return typeBase->build();
 }
 
 void PVRequestMapper::compute(const PVStructure &base,
@@ -96,7 +96,7 @@ void PVRequestMapper::compute(const PVStructure &base,
     }
 
     {
-        PVStructurePtr proto(getPVDataCreate()->createPVStructure(temp.typeRequested));
+        PVStructurePtr proto(temp.typeRequested->build());
 
         // base -> request may be sparce mapping
         temp.base2req.resize(base.getNextFieldOffset());

--- a/src/pv/pvIntrospect.h
+++ b/src/pv/pvIntrospect.h
@@ -118,6 +118,13 @@ class UnionArray;
 
 class BoundedString;
 
+class PVField;
+class PVScalar;
+class PVScalarArray;
+class PVStructure;
+class PVUnion;
+template<typename T> class PVValueArray;
+
 /**
  * typedef for a shared pointer to an immutable Field.
  */
@@ -341,6 +348,9 @@ public:
      */
     virtual std::ostream& dump(std::ostream& o) const = 0;
 
+   //! Allocate a new instance
+    std::tr1::shared_ptr<PVField> build() const;
+
 protected:
     /**
      * Constructor
@@ -387,6 +397,9 @@ public:
 
     virtual void serialize(ByteBuffer *buffer, SerializableControl *control) const OVERRIDE;
     virtual void deserialize(ByteBuffer *buffer, DeserializableControl *control) OVERRIDE FINAL;
+
+    //! Allocate a new instance
+    std::tr1::shared_ptr<PVScalar> build() const;
     
 protected:
     Scalar(ScalarType scalarType);
@@ -492,6 +505,9 @@ public:
 
     virtual void serialize(ByteBuffer *buffer, SerializableControl *control) const OVERRIDE;
     virtual void deserialize(ByteBuffer *buffer, DeserializableControl *control) OVERRIDE FINAL;
+
+    //! Allocate a new instance
+     std::tr1::shared_ptr<PVScalarArray> build() const;
     
     virtual ~ScalarArray();
 private:
@@ -594,6 +610,9 @@ public:
     virtual void serialize(ByteBuffer *buffer, SerializableControl *control) const OVERRIDE FINAL;
     virtual void deserialize(ByteBuffer *buffer, DeserializableControl *control) OVERRIDE FINAL;
 
+    //! Allocate a new instance
+     std::tr1::shared_ptr<PVValueArray<std::tr1::shared_ptr<PVStructure> > > build() const;
+
 protected:
     /**
      * Constructor.
@@ -634,6 +653,9 @@ public:
 
     virtual void serialize(ByteBuffer *buffer, SerializableControl *control) const OVERRIDE FINAL;
     virtual void deserialize(ByteBuffer *buffer, DeserializableControl *control) OVERRIDE FINAL;
+
+    //! Allocate a new instance
+     std::tr1::shared_ptr<PVValueArray<std::tr1::shared_ptr<PVUnion> > > build() const;
 
 protected:
     /**
@@ -742,7 +764,10 @@ public:
 
     virtual void serialize(ByteBuffer *buffer, SerializableControl *control) const OVERRIDE FINAL;
     virtual void deserialize(ByteBuffer *buffer, DeserializableControl *control) OVERRIDE FINAL;
-    
+
+    //! Allocate a new instance
+    std::tr1::shared_ptr<PVStructure> build() const;
+
 protected:
     Structure(StringArray const & fieldNames, FieldConstPtrArray const & fields, std::string const & id = defaultId());
 private:
@@ -877,6 +902,9 @@ public:
 
     virtual void serialize(ByteBuffer *buffer, SerializableControl *control) const OVERRIDE FINAL;
     virtual void deserialize(ByteBuffer *buffer, DeserializableControl *control) OVERRIDE FINAL;
+
+    //! Allocate a new instance
+    std::tr1::shared_ptr<PVUnion> build() const;
     
 protected:
    Union();
@@ -910,6 +938,11 @@ class epicsShareClass FieldBuilder :
     public std::tr1::enable_shared_from_this<FieldBuilder>
 {
 public:
+    //! Create a new instance of in-line @c Field builder.
+    static FieldBuilderPtr begin();
+    //! Create a new instance of in-line @c Field builder pre-initialized with and existing Structure
+    static FieldBuilderPtr begin(StructureConstPtr S);
+
 	/**
 	 * Set ID of an object to be created.
 	 * @param id id to be set.

--- a/src/pv/valueBuilder.cpp
+++ b/src/pv/valueBuilder.cpp
@@ -285,7 +285,7 @@ PVStructure::shared_pointer ValueBuilder::buildPVStructure() const
         type = tbuild->createStructure();
     }
 
-    PVStructure::shared_pointer root(getPVDataCreate()->createPVStructure(type));
+    PVStructure::shared_pointer root(type->build());
 
     child_struct::storeStruct(*this, root);
 

--- a/testApp/pv/testPVData.cpp
+++ b/testApp/pv/testPVData.cpp
@@ -384,7 +384,7 @@ static void testRequest()
     StructureConstPtr topStructure = fieldCreate->createStructure(
         topNames,topFields);
 cout << *topStructure << endl;
-    PVStructurePtr pvTop = pvDataCreate->createPVStructure(topStructure);
+    PVStructurePtr pvTop = topStructure->build();
 cout << *pvTop << endl;
 cout << *pvTop->getStructure() << endl;
 PVStructurePtr xxx = pvTop->getSubField<PVStructure>("record");
@@ -522,7 +522,7 @@ static void testFieldAccess()
             endNested()->
             createStructure();
 
-    PVStructurePtr fld = pvDataCreate->createPVStructure(tdef);
+    PVStructurePtr fld = tdef->build();
 
     PVIntPtr a = fld->getSubField<PVInt>("test");
     testOk1(a.get() != NULL);
@@ -628,11 +628,11 @@ static void testFieldAccess()
 
 static void testAnyScalar()
 {
-    PVStructurePtr value(getPVDataCreate()->createPVStructure(getFieldCreate()->createFieldBuilder()
-                                                              ->add("a", pvInt)
-                                                              ->add("b", pvDouble)
-                                                              ->add("c", pvString)
-                                                              ->createStructure()));
+    PVStructurePtr value(FieldBuilder::begin()
+                         ->add("a", pvInt)
+                         ->add("b", pvDouble)
+                         ->add("c", pvString)
+                         ->createStructure()->build());
 
     PVIntPtr a(value->getSubFieldT<PVInt>("a"));
     PVDoublePtr b(value->getSubFieldT<PVDouble>("b"));

--- a/testApp/pv/testPVStructureArray.cpp
+++ b/testApp/pv/testPVStructureArray.cpp
@@ -38,7 +38,7 @@ static void testBasic()
     StructureArrayConstPtr alarmtype(
         fieldCreate->createStructureArray(standardField->alarm()));
 
-    PVStructureArrayPtr alarmarr(pvDataCreate->createPVStructureArray(alarmtype));
+    PVStructureArrayPtr alarmarr(alarmtype->build());
 
     testOk1(alarmarr->getLength()==0);
 
@@ -69,7 +69,7 @@ static void testCompress()
     StructureArrayConstPtr alarmtype(
         fieldCreate->createStructureArray(standardField->alarm()));
 
-    PVStructureArrayPtr alarmarr(pvDataCreate->createPVStructureArray(alarmtype));
+    PVStructureArrayPtr alarmarr(alarmtype->build());
 
     alarmarr->setLength(5);
 
@@ -85,10 +85,10 @@ static void testCompress()
 
     PVStructureArray::svector contents(10);
 
-    contents[2] = pvDataCreate->createPVStructure(standardField->alarm());
-    contents[4] = pvDataCreate->createPVStructure(standardField->alarm());
-    contents[5] = pvDataCreate->createPVStructure(standardField->alarm());
-    contents[8] = pvDataCreate->createPVStructure(standardField->alarm());
+    contents[2] = standardField->alarm()->build();
+    contents[4] = standardField->alarm()->build();
+    contents[5] = standardField->alarm()->build();
+    contents[8] = standardField->alarm()->build();
 
     PVStructureArray::const_svector scont(freeze(contents));
 
@@ -117,11 +117,11 @@ static void testRemove()
     PVStructureArray::svector contents(10);
     
     for(size_t i=0; i<contents.size(); i++)
-        contents[i] = pvDataCreate->createPVStructure(standardField->alarm());
+        contents[i] = standardField->alarm()->build();
 
     StructureArrayConstPtr alarmtype(
         fieldCreate->createStructureArray(standardField->alarm()));
-    PVStructureArrayPtr alarmarr(pvDataCreate->createPVStructureArray(alarmtype));
+    PVStructureArrayPtr alarmarr(alarmtype->build());
 
     PVStructureArray::const_svector scont(freeze(contents));
 
@@ -147,10 +147,10 @@ static void testFromRaw()
     testDiag("Test structure array external allocation for shared_vector");
 
     PVStructurePtr* raw = new PVStructurePtr[4];
-    raw[0] = pvDataCreate->createPVStructure(standardField->alarm());
-    raw[1] = pvDataCreate->createPVStructure(standardField->alarm());
-    raw[2] = pvDataCreate->createPVStructure(standardField->alarm());
-    raw[3] = pvDataCreate->createPVStructure(standardField->alarm());
+    raw[0] = standardField->alarm()->build();
+    raw[1] = standardField->alarm()->build();
+    raw[2] = standardField->alarm()->build();
+    raw[3] = standardField->alarm()->build();
 
     PVStructureArray::svector cont(raw, 1, 2);
 }


### PR DESCRIPTION
Boilerplate reduction for using FieldBuilder and creating PVField instances.  Turns:

```c++
    PVStructurePtr value(getPVDataCreate()->createPVStructure(getFieldCreate()->createFieldBuilder()
                                                              ->add("a", pvInt)
                                                              ->add("b", pvDouble)
                                                              ->add("c", pvString)
                                                              ->createStructure()));
```

into:

```c++
    PVStructurePtr value(FieldBuilder::build()
                         ->add("a", pvInt)
                         ->add("b", pvDouble)
                         ->add("c", pvString)
                         ->createStructure()->create());
```

I've long been annoyed at how verbose Structure creation is.  Hearing @shroffk complaining about the same, and suggesting something like this has motivated me to do something about it.