### PR TITLE
Disabled NEED_OLL_FUNCS for Visual Studio 2013+

### DIFF
--- a/src/misc/parseToPOD.cpp
+++ b/src/misc/parseToPOD.cpp
@@ -254,7 +254,7 @@ epicsParseFloat(const char *str, float *to, char **units)
 #endif
 
 // Sometimes we have to provide our own copy of strtoll()
-#if defined(_WIN32) && !defined(_MINGW)
+#if defined(_WIN32) && !defined(_MINGW) && !(defined(_MSC_VER) && _MSC_VER >= 1800)
 // On Windows with MSVC, Base-3.15 provides strtoll()
 #    define NEED_OLL_FUNCS (EPICS_VERSION_INT < VERSION_INT(3,15,0,1))
 #elif defined(vxWorks)

--- a/src/misc/parseToPOD.cpp
+++ b/src/misc/parseToPOD.cpp
@@ -254,7 +254,7 @@ epicsParseFloat(const char *str, float *to, char **units)
 #endif
 
 // Sometimes we have to provide our own copy of strtoll()
-#if defined(_WIN32) && !defined(_MINGW) && !(defined(_MSC_VER) && _MSC_VER >= 1800)
+#if defined(_MSC_VER) && _MSC_VER < 1800
 // On Windows with MSVC, Base-3.15 provides strtoll()
 #    define NEED_OLL_FUNCS (EPICS_VERSION_INT < VERSION_INT(3,15,0,1))
 #elif defined(vxWorks)


### PR DESCRIPTION
The parseToPOD.cpp file defines strtoll and strtoull for EPICS Base < R3.15.0.1. This is not necessary with Visual Studio 2013+.

This is related to two prior, conflicting commits. The first, 587f81f5115ce5c785eff876c5b591eee352f98f, checks the version of _MSC_VER before defining strtoll and strtoull. The second, 50b82137813067d15227c3580ce18a287e096bbd, removes the check for _MSC_VER and tests only the version of EPICS base.

As far as I understand it, this should check against both _MSC_VER and the EPICS base version.