### PR TITLE
Change logic for selecting when to use unaligned access

### DIFF
--- a/src/misc/pv/byteBuffer.h
+++ b/src/misc/pv/byteBuffer.h
@@ -157,7 +157,7 @@ struct swap<8> {
  * in execution time and/or object code size of byte-wise copy.
  */
 
-#ifdef _ARCH_PPC
+#if defined(_ARCH_PPC) || defined(__arm__) || defined(_M_ARM)
 
 template<typename T>
 union alignu {

--- a/src/misc/pv/byteBuffer.h
+++ b/src/misc/pv/byteBuffer.h
@@ -150,14 +150,17 @@ struct swap<8> {
 #undef _PVA_swap64
 
 /* PVD serialization doesn't pay attention to alignement,
- * which some targets really care about and treat unaligned
+ * which some targets (ARM and powerpc) really care about and treat unaligned
  * access as a fault, or with a heavy penalty (~= to a syscall).
  *
  * For those targets,, we will have to live with the increase
  * in execution time and/or object code size of byte-wise copy.
+ *
+ * Treat x86 32/64 as an outlier, and assume all other targets
+ * need, or greatly benefit, from aligned access.
  */
 
-#if defined(_ARCH_PPC) || defined(__arm__) || defined(_M_ARM)
+#if !(defined(__x86_64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_IX86))
 
 template<typename T>
 union alignu {


### PR DESCRIPTION
Historically, `ByteBuffer` would use unaligned memory access.  This has caused problems before w/ PPC (#54 and #74).

I was under the impression that ARM/Linux would automatically handle unaligned access.  However, it appears (#84) that "fixup" logic is both incomplete, and conditional.  Incomplete in that some floating point instruction are not handled[1], and conditional[2] in that it can be switched on/off at runtime via `/proc/cpu/alignment`.

In the hope of avoiding further issues, this PR switches the `#if` logic to only use unaligned access on i386 and amd64 w/ GCC, clang, and MSVC.  The preprocessor macro names are selected with reference to my [usual first stop](https://sourceforge.net/p/predef/wiki/Architectures/), as well as some [MS docs](https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170), and local testing with GCC 10 and clang 11.

[1] The example [here](http://www.invece.org/news/111) still faults with a raspbian kernel `6.1.21-v7+` in "fixup" mode.

[2] see `/proc/cpu/alignment` in the [Linux docs](https://www.kernel.org/doc/Documentation/arm/mem_alignment)