### PR TITLE
Fix issue detected by cppcheck / sonarqube

### DIFF
--- a/testApp/pv/testOperators.cpp
+++ b/testApp/pv/testOperators.cpp
@@ -33,7 +33,7 @@ MAIN(testOperators)
     PVDoublePtr pvValue = pvStructure->getSubField<PVDouble>("value");
     *pvValue <<= testDV;
 
-    double dv;
+    double dv = 0.;
     *pvValue >>= dv;
     testOk1(testDV == dv);
 


### PR DESCRIPTION
A (non-functional trivial) change that silences/fixes an issue reported by cppcheck / sonar. Intended to make EPICS Base pass the ITER quality gates again.

- silence warning about uninitialized local variable