### PR TITLE
Update debugPtr to work with EPICS base 7.0.7

### DIFF
--- a/src/misc/debugPtr.cpp
+++ b/src/misc/debugPtr.cpp
@@ -35,7 +35,7 @@ void shared_ptr_base::track_new()
 }
 
 // create new tracker if ptr!=nullptr, otherwise clear
-void shared_ptr_base::track_new(void* ptr)
+void shared_ptr_base::track_new(const void* ptr)
 {
     track_clear();
     if(ptr){

--- a/src/misc/pv/debugPtr.h
+++ b/src/misc/pv/debugPtr.h
@@ -78,7 +78,7 @@ protected:
     // add ourselves to tracker
     void track_new();
     // create new tracker if ptr!=nullptr, otherwise clear
-    void track_new(void* ptr);
+    void track_new(const void* ptr);
     // copy tracker and add ourself
     void track_assign(const shared_ptr_base& o);
     void track_clear();
@@ -286,6 +286,7 @@ public:
 
     long use_count() const noexcept { return real.use_count(); }
     bool unique() const noexcept { return real.unique(); }
+    bool expired() const noexcept { return real.expired(); }
 };
 
 template<class Base>
@@ -316,13 +317,12 @@ do_enable_shared_from_this(const shared_ptr<Store>& dest,
     self->xxInternalSelf = actual;
 }
 
-}} // namespace epics::debug
-
 template<typename T>
-inline std::ostream& operator<<(std::ostream& strm, const epics::debug::shared_ptr<T>& ptr)
+inline std::ostream& operator<<(std::ostream& strm, const shared_ptr<T>& ptr)
 {
     strm<<ptr.get();
     return strm;
 }
 
+}} // namespace epics::debug
 #endif // DEBUGPTR_H


### PR DESCRIPTION
There are at least two changes to EPICS base since the addition of debugPtr:
* In pvAccess/**/dbdToPv.cpp, a write to an ostream was added (also in pvData/**/testSerialization.cpp) which does not resolve correctly when the operator<< overload is in the global namespace.
* In pvAccess/**/caChannel.cpp, weak_ptr->expired() was added

The interface to deal with each of these has been added.

Fixes https://github.com/epics-base/pvDataCPP/issues/88