### PR TITLE
Fix a couple bugs

### DIFF
--- a/src/factory/Convert.cpp
+++ b/src/factory/Convert.cpp
@@ -27,7 +27,7 @@ using std::string;
 namespace epics { namespace pvData {
 
 
-static std::vector<string> split(string commaSeparatedList) {
+static std::vector<string> split(const string& commaSeparatedList) {
     string::size_type numValues = 1;
     string::size_type index=0;
     while(true) {

--- a/src/misc/anyscalar.cpp
+++ b/src/misc/anyscalar.cpp
@@ -31,7 +31,7 @@ AnyScalar::AnyScalar(const AnyScalar& o)
 }
 
 #if __cplusplus>=201103L
-AnyScalar::AnyScalar(AnyScalar&& o)
+AnyScalar::AnyScalar(AnyScalar&& o) noexcept
     :_stype(o._stype)
 {
     typedef std::string string;
@@ -136,7 +136,7 @@ void AnyScalar::swap(AnyScalar& o) {
 }
 const void* AnyScalar::bufferUnsafe() const {
     if(_stype==pvString) {
-        return as<std::string>().c_str();
+        return ref<std::string>().c_str();
     } else {
         return _wrap.blob;
     }

--- a/src/misc/pv/anyscalar.h
+++ b/src/misc/pv/anyscalar.h
@@ -123,7 +123,7 @@ public:
     AnyScalar(const AnyScalar& o);
 
 #if __cplusplus>=201103L
-    AnyScalar(AnyScalar&& o);
+    AnyScalar(AnyScalar&& o) noexcept;
 #endif
 
     inline ~AnyScalar() {clear();}
@@ -140,7 +140,7 @@ public:
     }
 
 #if __cplusplus>=201103L
-    inline AnyScalar& operator=(AnyScalar&& o) {
+    inline AnyScalar& operator=(AnyScalar&& o) noexcept {
         clear();
         swap(o);
         return *this;

--- a/src/misc/reftrack.cpp
+++ b/src/misc/reftrack.cpp
@@ -271,10 +271,10 @@ char* epicsRefSnapshotCurrent()
         snap.update();
         std::ostringstream strm;
         strm<<snap;
-        const char *str = strm.str().c_str();
-        char *ret = (char*)malloc(strlen(str)+1);
+        std::string str = strm.str();
+        char *ret = (char*)malloc(str.length()+1);
         if(ret)
-            strcpy(ret, str);
+            strcpy(ret, str.c_str());
         return ret;
     }catch(std::exception& e){
         return epicsStrDup(e.what());


### PR DESCRIPTION
These were issues reported by clang-tidy as I was running that on epics-base.

* `AnyScalar::bufferUnsafe()` was returning a pointer to the data of an `std::string` living on the stack.
* `ostringstream::str()` returns `std::string` by value, so we can't keep a pointer to its data without first turning it into an lvalue.
* `split` should take the string as a reference to avoid unnecessary copies.
* Added `noexcept` to the move ctor/assignment of `AnyScalar`