### PR TITLE
Allow Timers to be cancelled during callback execution

### DIFF
--- a/src/misc/pv/timer.h
+++ b/src/misc/pv/timer.h
@@ -60,6 +60,8 @@ private:
     epicsTime timeToRun;
     double period;
     bool onList;
+    bool cancelled;
+    bool processing;
     friend class Timer;
     struct IncreasingTime;
 };


### PR DESCRIPTION
Useful for when e.g. a periodic timer needs to cancel itself. Currently periodic timers cannot cancel from inside their `callback()`

This is for some ongoing work on pvAccess for the codeathon.