### PR TITLE
Request JSON and JSON5 string output explicitly from PVA tools

### DIFF
--- a/src/factory/printer.cpp
+++ b/src/factory/printer.cpp
@@ -401,12 +401,11 @@ void printRaw(std::ostream& strm, const PVStructure::Formatter& format, const PV
 
 std::ostream& operator<<(std::ostream& strm, const PVStructure::Formatter& format)
 {
-    if(format.xfmt==PVStructure::Formatter::JSON) {
+    if(format.xfmt==PVStructure::Formatter::JSON || \
+       format.xfmt==PVStructure::Formatter::JSON5) {
         JSONPrintOptions opts;
         opts.multiLine = false;
-#if EPICS_VERSION_INT>=VERSION_INT(7,0,6,1)
-        opts.json5 = true;
-#endif
+        opts.json5 = format.xfmt==PVStructure::Formatter::JSON5 ? true : false;
         printJSON(strm, format.xtop, format.xshow ? *format.xshow : BitSet().set(0), opts);
         strm<<'\n';
         return strm;

--- a/src/pv/pvData.h
+++ b/src/pv/pvData.h
@@ -881,6 +881,7 @@ public:
             Raw,
             NT,
             JSON,
+            JSON5,
         };
     private:
         const PVStructure& xtop;


### PR DESCRIPTION
- Eliminated the json5 opt test on EPICS base version
- Explicitly pass `-M json` for regular JSON string request
- Using `-M json5` for JSON5 string request

The original intention is to make the JSON string output from PVA tools easily handled by Python without installing third-party libraries for JSON5. However, the `-M json` returns the JSON5 format by default (EPICS base > 7.0.6.1).