### PR TITLE
Add -S option to pvget/pvmonitor to stringify byte arrays

### DIFF
--- a/src/factory/printer.cpp
+++ b/src/factory/printer.cpp
@@ -434,12 +434,36 @@ std::ostream& operator<<(std::ostream& strm, const PVStructure::Formatter& forma
                     return strm;
 
                 case scalarArray:
+                {
                     strm<<format::indent();
                     printTimeT(strm, format.xtop);
                     printAlarmT(strm, format.xtop);
-                    strm<<std::setprecision(6)<<*static_cast<const PVScalarArray*>(value.get())<<'\n';
-                    return strm;
 
+                    const PVScalarArray* pvArray = static_cast<const PVScalarArray*>(value.get());
+                    ScalarArrayConstPtr scalarArray = pvArray->getScalarArray();
+
+                    // Stringify byte arrays if requested
+                    if (format.xarrAsStr && scalarArray && scalarArray->getElementType() == pvByte) {
+                        shared_vector<const int8_t> byteArray;
+                        pvArray->getAs(byteArray);
+
+                        if (!byteArray.empty()) {
+                            const char* str = reinterpret_cast<const char*>(byteArray.data());
+                            const size_t slen = strnlen(str, byteArray.size());
+                            const size_t buflen = epicsStrnEscapedFromRawSize(str, slen);
+
+                            std::vector<char> buf(buflen+1);
+                            epicsStrnEscapedFromRaw(buf.data(), buf.size(), str, slen);
+
+                            strm<<buf.data();
+                        }
+                    } else {
+                        strm<<std::setprecision(6);
+                        strm<<*pvArray;
+                    }
+                    strm<<'\n';
+                    return strm;
+                }
                 case structure:
                     if(printEnumT(strm, format.xtop, true)) {
                         strm<<'\n';

--- a/src/pv/pvData.h
+++ b/src/pv/pvData.h
@@ -888,6 +888,7 @@ public:
         const BitSet* xhighlight;
         mode_t xmode;
         format_t xfmt;
+        bool xarrAsStr;
     public:
         explicit Formatter(const PVStructure& top)
             :xtop(top)
@@ -895,6 +896,7 @@ public:
             ,xhighlight(0)
             ,xmode(Auto)
             ,xfmt(NT)
+            ,xarrAsStr(false)
         {}
 
         // those fields (and their parents) to be printed.  non-NT mode.
@@ -905,6 +907,8 @@ public:
         FORCE_INLINE Formatter& mode(mode_t m) { xmode = m; return *this; }
 
         FORCE_INLINE Formatter& format(format_t f) { xfmt = f; return *this; }
+
+        FORCE_INLINE Formatter& arrayAsString(bool b) { xarrAsStr = b; return *this; }
 
         friend epicsShareFunc std::ostream& operator<<(std::ostream& strm, const Formatter& format);
         friend void printRaw(std::ostream& strm, const PVStructure::Formatter& format, const PVStructure& cur);


### PR DESCRIPTION
This emulates the behavior of the caget -S option. Byte arrays are displayed as strings.

Example (without -S):
```
$ pvget SIOC:TST:SYS0:APP_DIR
SIOC:TST:SYS0:APP_DIR 2026-03-17 23:09:56.242  [47,109,101,100,105,97,47,66,105,103,68,114,105,118,101,47,80,114,111,106,101,99,116,115,47,101,112,105,99,115,47,105,111,99,47,97,116,108,97,115,45,103,105,116,47,105,111,99,66,111,111,116,47,115,105,111,99,45,116,115,116,45,115,121,115,48,0]
```

Example (with -S):
```
$ pvget -S SIOC:TST:SYS0:APP_DIR
SIOC:TST:SYS0:APP_DIR 2026-03-17 22:39:05.669  /media/BigDrive/Projects/epics/ioc/atlas-git/iocBoot/sioc-tst-sys0
```

pvAccess PR: https://github.com/epics-base/pvAccessCPP/pull/222