### PR TITLE
Add protection from some network issues

### DIFF
--- a/src/factory/PVDataCreateFactory.cpp
+++ b/src/factory/PVDataCreateFactory.cpp
@@ -409,23 +409,19 @@ template<>
 void PVValueArray<string>::deserialize(ByteBuffer *pbuffer,
         DeserializableControl *pcontrol) {
 
-    size_t size = this->getArray()->getArraySizeType() == Array::fixed ?
-                this->getArray()->getMaximumCapacity() :
-                SerializeHelper::readSize(pbuffer, pcontrol);
+    const size_t size = this->getArray()->getArraySizeType() == Array::fixed ?
+        this->getArray()->getMaximumCapacity() :
+        SerializeHelper::readSize(pbuffer, pcontrol);
 
-    svector nextvalue(thaw(value));
+    svector nextvalue(thaw(value)); // Reuse old storage
 
-    // Decide if we must re-allocate
-    if(size > nextvalue.size() || !nextvalue.unique())
-        nextvalue.resize(size);
-    else if(size < nextvalue.size())
-        nextvalue.slice(0, size);
-
-
-    string * pvalue = nextvalue.data();
-    for(size_t i = 0; i<size; i++) {
-        pvalue[i] = SerializeHelper::deserializeString(pbuffer,
-                                                       pcontrol);
+    // Don't trust 'size' for new or larger arrays, start
+    // small and grow them as elements are deserialized.
+    nextvalue.resize(0);
+    nextvalue.reserve(size < 64 ? size : 64);
+    for (size_t i = 0; i<size; i++) {
+        nextvalue.push_back(
+            SerializeHelper::deserializeString(pbuffer, pcontrol));
     }
     value = freeze(nextvalue);
     // inform about the change?

--- a/src/factory/PVStructureArray.cpp
+++ b/src/factory/PVStructureArray.cpp
@@ -160,28 +160,28 @@ void PVStructureArray::deserialize(ByteBuffer *pbuffer,
         DeserializableControl *pcontrol) {
     svector data(reuse());
 
-    size_t size = this->getArray()->getArraySizeType() == Array::fixed ?
-                this->getArray()->getMaximumCapacity() :
-                SerializeHelper::readSize(pbuffer, pcontrol);
-
-    data.resize(size);
+    const size_t size = this->getArray()->getArraySizeType() == Array::fixed ?
+        this->getArray()->getMaximumCapacity() :
+        SerializeHelper::readSize(pbuffer, pcontrol);
 
     StructureConstPtr structure = structureArray->getStructure();
 
     PVDataCreatePtr pvDataCreate = getPVDataCreate();
 
+    // Don't trust 'size' for new or larger arrays, start
+    // small and grow them as elements are deserialized.
+    data.resize(0);
+    data.reserve(size < 64 ? size : 64);
     for(size_t i = 0; i<size; i++) {
         pcontrol->ensureData(1);
         size_t temp = pbuffer->getByte();
-        if(temp==0) {
-            data[i].reset();
+
+        PVStructurePtr pvStructure;
+        if(temp!=0) {
+            pvStructure = pvDataCreate->createPVStructure(structure);
+            pvStructure->deserialize(pbuffer, pcontrol);
         }
-        else {
-            if(data[i].get()==NULL || !data[i].unique()) {
-                data[i] = pvDataCreate->createPVStructure(structure);
-            }
-            data[i]->deserialize(pbuffer, pcontrol);
-        }
+        data.push_back(pvStructure);
     }
     replace(freeze(data)); // calls postPut()
 }

--- a/src/factory/PVUnion.cpp
+++ b/src/factory/PVUnion.cpp
@@ -158,21 +158,26 @@ void PVUnion::deserialize(ByteBuffer *pbuffer, DeserializableControl *pcontrol)
     }
     else
     {
-        int32 previousSelector = selector;
-        selector = static_cast<int32>(SerializeHelper::readSize(pbuffer, pcontrol));
-        if (selector != UNDEFINED_INDEX)
+        int32 index = static_cast<int32>(SerializeHelper::readSize(pbuffer, pcontrol));
+        if (index == UNDEFINED_INDEX)
         {
-            if (selector != previousSelector)
+            selector = index;
+            value.reset();
+        }
+        else if (index < 0 || size_t(index) >= unionPtr->getFields().size())
+            throw std::runtime_error("union index out of bounds");
+        else
+        {
+            if (selector != index)
             {
-                FieldConstPtr field = unionPtr->getField(selector);
+                selector = index;
+                FieldConstPtr field = unionPtr->getField(index);
                 // try to reuse existing field instance
                 if (!value.get() || *value->getField() != *field)
                     value = pvDataCreate->createPVField(field);
             }
             value->deserialize(pbuffer, pcontrol);
         }
-        else
-            value.reset();
     }
 }
 

--- a/src/factory/PVUnionArray.cpp
+++ b/src/factory/PVUnionArray.cpp
@@ -159,28 +159,28 @@ void PVUnionArray::deserialize(ByteBuffer *pbuffer,
         DeserializableControl *pcontrol) {
     svector data(reuse());
 
-    size_t size = this->getArray()->getArraySizeType() == Array::fixed ?
-                this->getArray()->getMaximumCapacity() :
-                SerializeHelper::readSize(pbuffer, pcontrol);
-
-    data.resize(size);
+    const size_t size = this->getArray()->getArraySizeType() == Array::fixed ?
+        this->getArray()->getMaximumCapacity() :
+        SerializeHelper::readSize(pbuffer, pcontrol);
 
     UnionConstPtr punion = unionArray->getUnion();
 
     PVDataCreatePtr pvDataCreate = getPVDataCreate();
 
+    // Don't trust 'size' for new or larger arrays, start
+    // small and grow them as elements are deserialized.
+    data.resize(0);
+    data.reserve(size < 64 ? size : 64);
     for(size_t i = 0; i<size; i++) {
         pcontrol->ensureData(1);
         size_t temp = pbuffer->getByte();
-        if(temp==0) {
-            data[i].reset();
+
+        PVUnionPtr pvUnion;
+        if(temp!=0) {
+            pvUnion = pvDataCreate->createPVUnion(punion);
+            pvUnion->deserialize(pbuffer, pcontrol);
         }
-        else {
-            if(data[i].get()==NULL || !data[i].unique()) {
-                data[i] = pvDataCreate->createPVUnion(punion);
-            }
-            data[i]->deserialize(pbuffer, pcontrol);
-        }
+        data.push_back(pvUnion);
     }
     replace(freeze(data)); // calls postPut()
 }

--- a/src/misc/bitSet.cpp
+++ b/src/misc/bitSet.cpp
@@ -337,16 +337,14 @@ namespace epics { namespace pvData {
     }
 
     void BitSet::deserialize(ByteBuffer* buffer, DeserializableControl* control) {
+        size_t size = SerializeHelper::readSize(buffer, control);
+        uint32 bytes = (size == (size_t) -1) ? 0 : static_cast<uint32>(size);
 
-        uint32 bytes = static_cast<uint32>(SerializeHelper::readSize(buffer, control)); // in bytes
+        // Validate availability before allocating storage
+        control->ensureData(bytes);
 
         size_t wordsInUse = (bytes + 7) / BYTES_PER_WORD;
         words.resize(wordsInUse);
-
-        if (wordsInUse == 0)
-            return;
-
-        control->ensureData(bytes);
 
         uint32 i = 0;
         uint32 longs = bytes / 8;

--- a/src/misc/pv/serializeHelper.h
+++ b/src/misc/pv/serializeHelper.h
@@ -50,7 +50,7 @@ namespace epics {
              *
              * @param[in] buffer deserialization buffer.
              * @param[in] control the DeserializableControl.
-             * @returns array size.
+             * @returns array size, or (size_t) -1.
              */
             static std::size_t readSize(ByteBuffer* buffer,
                     DeserializableControl* control);
@@ -80,20 +80,18 @@ namespace epics {
 
             /**
              * std::string deserialization helper method.
-             * TODO This method cannot return "null", but Java implementation
-             * could have serialized "null" value as well. We need to decide
-             * how to deserialize "null".
              *
              * @param[in] buffer deserialization buffer
              * @param[in] control control
+             * @param[in] max length limit
              * @returns deserialized string
              *
              * @todo This method cannot return "null", but Java implementation
-             * could have serialized "null" value as well. We need to decide
-             * how to deserialize "null".
+             * could have serialized "null" value as well. This implementation
+             * returns an empty string in that event.
              */
             static std::string deserializeString(ByteBuffer* buffer,
-                    DeserializableControl* control);
+                    DeserializableControl* control, std::size_t max = INT32_MAX);
 
         private:
             SerializeHelper() {};
@@ -111,5 +109,7 @@ namespace epics {
 
     }
 }
+
+#define DESERIALIZE_STRING_HAS_LIMIT
 
 #endif /* SERIALIZEHELPER_H_ */

--- a/src/misc/serializeHelper.cpp
+++ b/src/misc/serializeHelper.cpp
@@ -47,12 +47,13 @@ namespace epics {
                 DeserializableControl* control) {
             control->ensureData(1);
             int8 b = buffer->getByte();
-            if(b==-1)
-                return -1;
-            else if(b==-2) {
+            if (b == -1)
+                return -1;  // NULL
+            else if (b == -2) {
                 control->ensureData(sizeof(int32));
                 int32 s = buffer->getInt();
-                if(s<0) THROW_BASE_EXCEPTION("negative size");
+                if (s < 0)
+                    THROW_BASE_EXCEPTION("negative size");
                 return s;
             }
             else
@@ -100,44 +101,37 @@ namespace epics {
         }
 
         string SerializeHelper::deserializeString(ByteBuffer* buffer,
-                DeserializableControl* control) {
+                DeserializableControl* control, std::size_t max) {
 
             std::size_t size = SerializeHelper::readSize(buffer, control);
-            if(size!=(size_t)-1)    // TODO null strings check, to be removed in the future
-            {
-                if (buffer->getRemaining()>=size)
-                {
-                    // entire string is in buffer, simply create a string out of it (copy)
-                    std::size_t pos = buffer->getPosition();
-                    string str(buffer->getBuffer()+pos, size);
-                    buffer->setPosition(pos+size);
-                    return str;
-                }
-                else
-                {
-                    string str;
-                    str.reserve(size);
-                    try {
-                        std::size_t i = 0;
-                        while(true) {
-                            std::size_t toRead = min(size-i, buffer->getRemaining());
-                            std::size_t pos = buffer->getPosition();
-                            str.append(buffer->getBuffer()+pos, toRead);
-                            buffer->setPosition(pos+toRead);
-                            i += toRead;
-                            if(i<size)
-                                control->ensureData(1); // at least one
-                            else
-                                break;
-                        }
-                        return str;
-                    } catch(...) {
-                        throw;
-                    }
-                }
+            if (size == (std::size_t) -1)
+                return std::string();   // NULL from old implementations
+
+            if (size > max)
+                THROW_BASE_EXCEPTION("string too long");
+
+            if (buffer->getRemaining() >= size) { // All present
+                std::size_t pos = buffer->getPosition();
+                string str(buffer->getBuffer() + pos, size);
+                buffer->setPosition(pos + size);
+                return str;
             }
-            else
-                return std::string();
+
+            string str;
+            str.reserve(size);
+            std::size_t i = 0;
+            while (true) {
+                std::size_t toRead = min(size-i, buffer->getRemaining());
+                std::size_t pos = buffer->getPosition();
+                str.append(buffer->getBuffer() + pos, toRead);
+                buffer->setPosition(pos + toRead);
+                i += toRead;
+                if (i < size)
+                    control->ensureData(1); // at least one
+                else
+                    break;
+            }
+            return str;
         }
     }
 }

--- a/src/misc/status.cpp
+++ b/src/misc/status.cpp
@@ -72,6 +72,14 @@ void Status::deserialize(ByteBuffer *buffer, DeserializableControl *flusher)
            m_stackDump.clear();
        }
     }
+    else if (typeCode < 0 || typeCode > STATUSTYPE_FATAL)
+    {
+        // Leave *this as fatal and throw
+        m_statusType = STATUSTYPE_FATAL;
+        m_message = "deserialized type code was invalid";
+        m_stackDump.clear();
+        THROW_BASE_EXCEPTION("invalid Status type code");
+    }
     else
     {
         m_statusType = (StatusType)typeCode;

--- a/testApp/misc/testBitSet.cpp
+++ b/testApp/misc/testBitSet.cpp
@@ -303,15 +303,57 @@ static void testSerialize()
 #undef TOFRO
 }
 
+static void testDeserializeOversize()
+{
+    testDiag("testDeserializeOversize");
+
+    // Size field declares INT32_MAX bytes but no payload follows: 0xFE
+    // long-form marker + big-endian int32. deserialize() must reject this
+    // via ensureData() before allocating a ~2GB backing store.
+    const char msg[] = {(char)0xFE, 0x7F, (char)0xFF, (char)0xFF, (char)0xFF};
+    BitSet dut;
+    ByteBuffer buf((char*)msg, sizeof(msg), EPICS_ENDIAN_BIG);
+    try {
+        deserializeFromBuffer(&dut, buf);
+        testFail("oversized BitSet size was not rejected");
+    } catch(std::exception& e) {
+        testPass("oversized BitSet size rejected: %s", e.what());
+    }
+}
+
+static void testDeserializeNull()
+{
+    testDiag("testDeserializeNull");
+
+    // A NULL size is encoded on the wire as the single byte 0xFF. Without
+    // the null check in deserialize() this would be cast to UINT32_MAX bytes
+    // and overflow the allocation size; it must instead yield an empty BitSet.
+    const char msg[] = {(char)0xFF};
+    BitSet dut;
+    dut.set(5); // ensure deserialize actually clears/replaces existing bits
+    ByteBuffer buf((char*)msg, sizeof(msg), EPICS_ENDIAN_BIG);
+    try {
+        deserializeFromBuffer(&dut, buf);
+        testPass("NULL BitSet size accepted");
+    } catch(std::exception& e) {
+        testFail("NULL BitSet size rejected: %s", e.what());
+    }
+    testOk1(dut.isEmpty());
+    testOk(buf.getRemaining()==0, "buffer remaining 0 == %u",
+        (unsigned)buf.getRemaining());
+}
+
 } // namespace
 
 MAIN(testBitSet)
 {
-    testPlan(90);
+    testPlan(94);
     testInitialize();
     testGetSetClearFlip();
     testOperators();
     testLogical();
     testSerialize();
+    testDeserializeOversize();
+    testDeserializeNull();
     return testDone();
 }

--- a/testApp/misc/testSerialization.cpp
+++ b/testApp/misc/testSerialization.cpp
@@ -849,11 +849,202 @@ void testFromString(int byteOrder)
     testOk1(_data->getSubFieldT<PVString>("Y")->get()=="testing");
 }
 
+
+static UnionConstPtr growTestUnion()
+{
+    static UnionConstPtr un(getFieldCreate()->createFieldBuilder()
+                            ->add("i", pvInt)
+                            ->add("d", pvDouble)
+                            ->createUnion());
+    return un;
+}
+
+// Structure array of alarm structures. Some elements are
+// NULL to use both branches of the deserialize loop.
+static PVStructureArrayPtr makeStructureArray(size_t n)
+{
+    PVStructureArrayPtr pv(getPVDataCreate()->createPVStructureArray(
+        getFieldCreate()->createStructureArray(getStandardField()->alarm())));
+    PVStructureArray::svector d(n);
+    for(size_t i=0; i<n; i++) {
+        if(i%7 != 0) {
+            PVStructurePtr s(getPVDataCreate()->createPVStructure(
+                getStandardField()->alarm()));
+            s->getSubFieldT<PVInt>("severity")->put(static_cast<int32>(i));
+            d[i] = s;
+        }
+    }
+    pv->replace(freeze(d));
+    return pv;
+}
+
+// Union array of 'n' unions, some NULL.
+static PVUnionArrayPtr makeUnionArray(size_t n)
+{
+    PVUnionArrayPtr pv(getPVDataCreate()->createPVUnionArray(
+        getFieldCreate()->createUnionArray(growTestUnion())));
+    PVUnionArray::svector d(n);
+    for(size_t i=0; i<n; i++) {
+        if(i%5 != 0) {
+            PVUnionPtr u(getPVDataCreate()->createPVUnion(growTestUnion()));
+            u->select<PVInt>("i")->put(static_cast<int32>(i));
+            d[i] = u;
+        }
+    }
+    pv->replace(freeze(d));
+    return pv;
+}
+
+// String array of distinct strings.
+static PVStringArrayPtr makeStringArray(size_t n)
+{
+    PVStringArrayPtr pv(std::tr1::static_pointer_cast<PVStringArray>(
+        getPVDataCreate()->createPVScalarArray(pvString)));
+    PVStringArray::svector d(n);
+    for(size_t i=0; i<n; i++) {
+        std::ostringstream oss;
+        oss << "s" << i;
+        d[i] = oss.str();
+    }
+    pv->replace(freeze(d));
+    return pv;
+}
+
+// Serialize 'field' and deserialize into 'target', testing
+// the reuse & grow branches of the deserializer.
+static void roundTripInto(const PVFieldPtr& field, const PVFieldPtr& target)
+{
+    size_t len = std::tr1::static_pointer_cast<PVArray>(field)->getLength();
+    buffer->clear();
+    field->serialize(buffer, flusher);
+    buffer->flip();
+    target->deserialize(buffer, control);
+    testOk(*field == *target, "grow/reuse round trip, %u elements",
+           (unsigned)len);
+}
+
+#if defined(__rtems__)
+#  include <rtems.h>
+#endif
+void testLargeArrayGrowth()
+{
+    testDiag("Testing deserialize growth of large variable arrays...");
+
+#if defined(__RTEMS_MAJOR__) && __RTEMS_MAJOR__ == 4 && __RTEMS_MINOR__ <= 9
+    // Avoid fatal errors on RT-4.9, resource limits?
+    testSkip(3 * (8 + 7), "Not run on this target");
+#else
+
+    static const size_t sizes[] = {0, 1, 63, 64, 65, 100, 129, 1100};
+
+    for(size_t k=0; k<NELEMENTS(sizes); k++) {
+        size_t n = sizes[k];
+
+        PVStructureArrayPtr sa(makeStructureArray(n));
+        PVUnionArrayPtr ua(makeUnionArray(n));
+        PVStringArrayPtr ta(makeStringArray(n));
+
+        roundTripInto(sa, getPVDataCreate()->createPVField(sa->getField()));
+        roundTripInto(ua, getPVDataCreate()->createPVField(ua->getField()));
+        roundTripInto(ta, getPVDataCreate()->createPVField(ta->getField()));
+    }
+
+    // Reuse: Test shrink and grow behavior,
+    // crossing 64 elements both ways.
+    static const size_t seq[] = {10, 100, 5, 200, 64, 65, 63};
+
+    PVFieldPtr saTarget(getPVDataCreate()->createPVField(
+        FieldConstPtr(getFieldCreate()->createStructureArray(
+            getStandardField()->alarm()))));
+    PVFieldPtr uaTarget(getPVDataCreate()->createPVField(
+        FieldConstPtr(getFieldCreate()->createUnionArray(growTestUnion()))));
+    PVFieldPtr taTarget(getPVDataCreate()->createPVField(
+        FieldConstPtr(getFieldCreate()->createScalarArray(pvString))));
+
+    for(size_t k=0; k<NELEMENTS(seq); k++) {
+        roundTripInto(makeStructureArray(seq[k]), saTarget);
+        roundTripInto(makeUnionArray(seq[k]), uaTarget);
+        roundTripInto(makeStringArray(seq[k]), taTarget);
+    }
+#endif
+}
+
+// Deserialize raw bytes into 'field', returning true on bad input.
+// Can't use 'control' which has a no-op ensureData().
+static bool rejects(FieldConstPtr field, const char* msg, size_t n,
+                    int order = EPICS_ENDIAN_BIG)
+{
+    PVFieldPtr pv(getPVDataCreate()->createPVField(field));
+    ByteBuffer buf((char*)msg, n, order);
+    try {
+        deserializeFromBuffer(pv.get(), buf);
+        return false;
+    } catch(std::exception&) {
+        return true;
+    }
+}
+
+// Feed malicious data to deserialize() methods for string, structure and
+// union arrays.
+void testMaliciousArrays()
+{
+    testDiag("Testing array deserialize() responses to malicious input...");
+
+    const FieldConstPtr strArr(getFieldCreate()->createScalarArray(pvString));
+    const FieldConstPtr structArr(getFieldCreate()->createStructureArray(
+        getStandardField()->alarm()));
+    const FieldConstPtr unionArr(getFieldCreate()->createUnionArray(
+        growTestUnion()));
+
+    // 1. Oversized msg:
+    //    0xFE long-form marker + INT32_MAX big-endian, NO payload.
+    const char oversize[] = {(char)0xFE, 0x7F, (char)0xFF, (char)0xFF, (char)0xFF};
+    testOk(rejects(strArr, oversize, sizeof(oversize)),
+           "oversized string array size rejected");
+    testOk(rejects(structArr, oversize, sizeof(oversize)),
+           "oversized structure array size rejected");
+    testOk(rejects(unionArr, oversize, sizeof(oversize)),
+           "oversized union array size rejected");
+
+    // 2. Truncated element stream:
+    //    Plausible size (100) then fewer elements than promised.
+    const char shortStruct[] = {0x64, 0x00, 0x00, 0x00};
+    const char shortUnion[]  = {0x64, 0x00, 0x00, 0x00};
+    testOk(rejects(structArr, shortStruct, sizeof(shortStruct)),
+           "truncated structure array rejected");
+    testOk(rejects(unionArr, shortUnion, sizeof(shortUnion)),
+           "truncated union array rejected");
+    //    String array 100, two 1-char strings, end in third element's size.
+    const char shortStr[] = {0x64, 0x01, 'a', 0x01, 'b'};
+    testOk(rejects(strArr, shortStr, sizeof(shortStr)),
+           "truncated string array rejected");
+
+    // 3. Negative size:
+    //    0xFE marker + INT32_MIN.
+    const char negsize[] = {(char)0xFE, (char)0x80, 0x00, 0x00, 0x00};
+    testOk(rejects(strArr, negsize, sizeof(negsize)),
+           "negative string array size rejected");
+    testOk(rejects(structArr, negsize, sizeof(negsize)),
+           "negative structure array size rejected");
+    testOk(rejects(unionArr, negsize, sizeof(negsize)),
+           "negative union array size rejected");
+
+    // 4. Bad nested elements in valid array:
+    //    Union array, 1 element (0x01), with index out of range.
+    const char badSelector[] = {0x01, 0x01, 0x05};
+    testOk(rejects(unionArr, badSelector, sizeof(badSelector)),
+           "union array element with out-of-range selector rejected");
+    //    Structure array, 1 element (0x01) with bad child structure (no data)
+    const char badStruct[] = {0x01, 0x01};
+    testOk(rejects(structArr, badStruct, sizeof(badStruct)),
+           "structure array element with truncated child rejected");
+}
+
 } // end namespace
 
 MAIN(testSerialization) {
 
-    testPlan(234);
+    testPlan(290);
 
     flusher = new SerializableControlImpl();
     control = new DeserializableControlImpl();
@@ -874,6 +1065,9 @@ MAIN(testSerialization) {
 
     testArraySizeType();
     testBoundedString();
+
+    testLargeArrayGrowth();
+    testMaliciousArrays();
 
     testToString(EPICS_ENDIAN_BIG);
     testToString(EPICS_ENDIAN_LITTLE);


### PR DESCRIPTION
Malicious traffic from the network wasn't being checked properly. These changes don't prevent sending huge arrays or string values, but they do stop issues related to overflows caused by negative sizes, which PVA specifies to be positive int32 values.

1. Limit allocation in `BitSet::deserialize()` to the size actually needed. Support deserializing a NULL value. Includes new tests.

2, 3. The `PVStructureArray`, `PVUnionArray` and `PVValueArray<string>` `deserialize()` methods now allocate their storage as data arrives, and reject negative sizes. Includes new basic and malicious tests.

4. Add a maximum string length to `SerializeHelper::deserializeString()`, with a default of INT32_MAX.

5. Protect `Status::::deserialize()` from a bad status.

6. Protect `PVUnion::deserialize()` from a bad selector value.